### PR TITLE
Add header guards to header files that lacks them

### DIFF
--- a/inst/include/cpp11/environment.hpp
+++ b/inst/include/cpp11/environment.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "cpp11/as.hpp"
 #include "cpp11/sexp.hpp"  // for sexp
 

--- a/inst/include/cpp11/external_pointer.hpp
+++ b/inst/include/cpp11/external_pointer.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cstddef>
 #include <memory>
 #include "cpp11/sexp.hpp"

--- a/inst/include/cpp11/list_of.hpp
+++ b/inst/include/cpp11/list_of.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "cpp11/list.hpp"
 
 namespace cpp11 {


### PR DESCRIPTION
Some files were missing header guards making it impossible to include them in multiple files