### PR TITLE
Optionally register quietly

### DIFF
--- a/R/register.R
+++ b/R/register.R
@@ -7,9 +7,10 @@
 #' In order to use `cpp_register()` the `cli`, `decor`, `desc`, `glue`,
 #' `tibble` and `vctrs` packages must also be installed.
 #' @param path The path to the package root directory
+#' @param quiet If `TRUE` suppresses output from this function
 #' @return The paths to the generated R and C++ source files (in that order).
 #' @export
-cpp_register <- function(path = ".") {
+cpp_register <- function(path = ".", quiet = FALSE) {
   stop_unless_installed(c("brio", "cli", "decor", "desc", "glue", "tibble", "vctrs"))
 
   r_path <- file.path(path, "R", "cpp11.R")
@@ -24,13 +25,13 @@ cpp_register <- function(path = ".") {
     return(invisible(character()))
   }
 
-  funs <- get_registered_functions(all_decorations, "cpp11::register")
+  funs <- get_registered_functions(all_decorations, "cpp11::register", quiet)
 
   package <- desc::desc_get("Package", file = file.path(path, "DESCRIPTION"))
 
   cpp_functions_definitions <- generate_cpp_functions(funs, package)
 
-  init <- generate_init_functions(get_registered_functions(all_decorations, "cpp11::init"))
+  init <- generate_init_functions(get_registered_functions(all_decorations, "cpp11::init", quiet))
 
   r_functions <- generate_r_functions(funs, package)
 
@@ -43,7 +44,9 @@ cpp_register <- function(path = ".") {
 
       '
   ))
-  cli::cli_alert_success("generated file {.file {basename(r_path)}}")
+  if (!quiet) {
+    cli::cli_alert_success("generated file {.file {basename(r_path)}}")
+  }
 
   call_entries <- get_call_entries(path)
 
@@ -90,14 +93,16 @@ cpp_register <- function(path = ".") {
       call_entries = glue::glue_collapse(call_entries, "\n")
   ))
 
-  cli::cli_alert_success("generated file {.file {basename(cpp_path)}}")
+  if (!quiet) {
+    cli::cli_alert_success("generated file {.file {basename(cpp_path)}}")
+  }
 
   invisible(c(r_path, cpp_path))
 }
 
 utils::globalVariables(c("name", "return_type", "line", "decoration", "context", ".", "functions", "res"))
 
-get_registered_functions <- function(decorations, tag) {
+get_registered_functions <- function(decorations, tag, quiet = FALSE) {
   if (NROW(decorations) == 0) {
     return(tibble::tibble(file = character(), line = integer(), decoration = character(), params = list(), context = list(), name = character(), return_type = character(), args = list()))
   }
@@ -109,7 +114,9 @@ get_registered_functions <- function(decorations, tag) {
   out <- out[!(names(out) %in% "functions")]
   out$decoration <- sub("::[[:alpha:]]+", "", out$decoration)
 
-  cli::cli_alert_info(glue::glue("{n} functions decorated with [[{tag}]]", n = nrow(out)))
+  if (!quiet) {
+    cli::cli_alert_info(glue::glue("{n} functions decorated with [[{tag}]]", n = nrow(out)))
+  }
 
   out
 }

--- a/man/cpp_register.Rd
+++ b/man/cpp_register.Rd
@@ -4,10 +4,12 @@
 \alias{cpp_register}
 \title{Generates wrappers for registered C++ functions}
 \usage{
-cpp_register(path = ".")
+cpp_register(path = ".", quiet = FALSE)
 }
 \arguments{
 \item{path}{The path to the package root directory}
+
+\item{quiet}{If \code{TRUE} suppresses output from this function}
 }
 \value{
 The paths to the generated R and C++ source files (in that order).

--- a/tests/testthat/test-register.R
+++ b/tests/testthat/test-register.R
@@ -549,6 +549,23 @@ extern \"C\" void R_init_testPkg(DllInfo* dll){
 
 ")
   })
+
+  it("can be run without messages", {
+    pkg <- local_package()
+    p <- pkg_path(pkg)
+    dir.create(file.path(p, "src"))
+    file.copy(test_path("single.cpp"), file.path(p, "src", "single.cpp"))
+    expect_silent(cpp_register(p, quiet = TRUE))
+  })
+
+
+  it("can be run with messages, by default", {
+    pkg <- local_package()
+    p <- pkg_path(pkg)
+    dir.create(file.path(p, "src"))
+    file.copy(test_path("single.cpp"), file.path(p, "src", "single.cpp"))
+    expect_message(cpp_register(p), "1 functions decorated with [[cpp11::register]]", fixed = TRUE)
+  })
 })
 
 describe("generate_init_functions", {


### PR DESCRIPTION
This PR adds an argument `quiet` that prevents the informational output from cli during registration. Ideally this would also be passed down by pkgbuild, though this looks like a long call path (build -> build_setup -> update_registration -> compile_rcpp_attributes -> cpp11::cpp_register).

The context here is that we're looking at using cpp11 rather than Rcpp in a code generation system, so am looking to avoid this noise when a user has passed a verbose/quiet flag in at our end - we can use `suppressMessages` but that's a big hammer.