### PR TITLE
Drop unneeded trailing semicolon

### DIFF
--- a/inst/include/cpp11/matrix.hpp
+++ b/inst/include/cpp11/matrix.hpp
@@ -105,4 +105,4 @@ using strings_matrix = matrix<r_vector<r_string>, r_vector<r_string>::proxy>;
 }  // namespace writable
 
 // TODO: Add tests for Matrix class
-};  // namespace cpp11
+}  // namespace cpp11


### PR DESCRIPTION
This PR eliminates a compiler warning seen with `-pedantic` with 8.4.0:

```
In file included from /home/u00u4okcre0eieqDxq357/R/x86_64-pc-linux-gnu-library/4.0/dust/include/dust/interface.hpp:6,
                 from sirs.cpp:4:
/home/u00u4okcre0eieqDxq357/R/x86_64-pc-linux-gnu-library/4.0/cpp11/include/cpp11/matrix.hpp:108:2: warning: extra ';' [-Wpedantic]
 };  // namespace cpp11
```