### PR TITLE
mark stop() with [[noreturn]] attribute

### DIFF
--- a/inst/include/cpp11/protect.hpp
+++ b/inst/include/cpp11/protect.hpp
@@ -200,6 +200,7 @@ inline void check_user_interrupt() {
 template <typename... Args>
 void stop [[noreturn]](const char* fmt, Args... args) {
   unwind_protect([&] { Rf_error(fmt, args...); });
+  // Compiler hint to allow [[noreturn]] attribute; this is never executed since Rf_error will longjmp
   throw std::runtime_error("stop()");
 }
 

--- a/inst/include/cpp11/protect.hpp
+++ b/inst/include/cpp11/protect.hpp
@@ -198,13 +198,15 @@ inline void check_user_interrupt() {
 }
 
 template <typename... Args>
-void stop(const char* fmt, Args... args) {
+void stop [[noreturn]](const char* fmt, Args... args) {
   unwind_protect([&] { Rf_error(fmt, args...); });
+  throw;
 }
 
 template <typename... Args>
-void stop(const std::string& fmt, Args... args) {
+void stop [[noreturn]](const std::string& fmt, Args... args) {
   unwind_protect([&] { Rf_error(fmt.c_str(), args...); });
+  throw;
 }
 
 template <typename... Args>

--- a/inst/include/cpp11/protect.hpp
+++ b/inst/include/cpp11/protect.hpp
@@ -200,13 +200,13 @@ inline void check_user_interrupt() {
 template <typename... Args>
 void stop [[noreturn]](const char* fmt, Args... args) {
   unwind_protect([&] { Rf_error(fmt, args...); });
-  throw;
+  throw std::runtime_error("stop()");
 }
 
 template <typename... Args>
 void stop [[noreturn]](const std::string& fmt, Args... args) {
   unwind_protect([&] { Rf_error(fmt.c_str(), args...); });
-  throw;
+  throw std::runtime_error("stop()");
 }
 
 template <typename... Args>


### PR DESCRIPTION
Not sure this the right syntax, but without the `throw;` I was getting compiler warnings. https://en.cppreference.com/w/cpp/language/attributes/noreturn

This is particularly useful when using switch'es, as in this example from `arrow`: 

```cpp
SEXP from_datum(arrow::Datum datum) {
  switch (datum.kind()) {
    case arrow::Datum::SCALAR:
      return cpp11::as_sexp(datum.scalar());

    case arrow::Datum::ARRAY:
      return cpp11::as_sexp(datum.make_array());

    case arrow::Datum::CHUNKED_ARRAY:
      return cpp11::as_sexp(datum.chunked_array());

    case arrow::Datum::RECORD_BATCH:
      return cpp11::as_sexp(datum.record_batch());

    case arrow::Datum::TABLE:
      return cpp11::as_sexp(datum.table());

    default:
      break;
  }

  auto str = datum.ToString();
  cpp11::stop("from_datum: Not implemented for Datum %s", str.c_str());
}
```

