### PR TITLE
allow = <bool> in writables::logicals.

### DIFF
--- a/cpp11test/src/test-logicals.cpp
+++ b/cpp11test/src/test-logicals.cpp
@@ -126,6 +126,14 @@ context("logicals-C++") {
 
     UNPROTECT(1);
   }
+  test_that("writable::logicals::proxy::operator=(bool)") {
+    cpp11::writable::logicals y(2);
+
+    y[0] = false;
+    y[1] = true;
+    expect_true(y[0] == TRUE);
+    expect_true(y[1] == FALSE);
+  }
   test_that("is_na(Rboolean)") {
     Rboolean x = TRUE;
     expect_true(!cpp11::is_na(x));

--- a/inst/include/cpp11/doubles.hpp
+++ b/inst/include/cpp11/doubles.hpp
@@ -49,7 +49,8 @@ typedef r_vector<double> doubles;
 namespace writable {
 
 template <>
-inline typename r_vector<double>::proxy& r_vector<double>::proxy::operator=(
+template <>
+inline typename r_vector<double>::proxy& r_vector<double>::proxy::operator=<double>(
     const double& rhs) {
   if (is_altrep_) {
     // NOPROTECT: likely too costly to unwind protect every set elt

--- a/inst/include/cpp11/integers.hpp
+++ b/inst/include/cpp11/integers.hpp
@@ -51,7 +51,8 @@ typedef r_vector<int> integers;
 namespace writable {
 
 template <>
-inline typename r_vector<int>::proxy& r_vector<int>::proxy::operator=(const int& rhs) {
+template <>
+inline typename r_vector<int>::proxy& r_vector<int>::proxy::operator=<int>(const int& rhs) {
   if (is_altrep_) {
     // NOPROTECT: likely too costly to unwind protect every set elt
     SET_INTEGER_ELT(data_, index_, rhs);

--- a/inst/include/cpp11/list.hpp
+++ b/inst/include/cpp11/list.hpp
@@ -55,7 +55,8 @@ typedef r_vector<SEXP> list;
 namespace writable {
 
 template <>
-inline typename r_vector<SEXP>::proxy& r_vector<SEXP>::proxy::operator=(const SEXP& rhs) {
+template <>
+inline typename r_vector<SEXP>::proxy& r_vector<SEXP>::proxy::operator=<SEXP>(const SEXP& rhs) {
   SET_VECTOR_ELT(data_, index_, rhs);
   return *this;
 }

--- a/inst/include/cpp11/logicals.hpp
+++ b/inst/include/cpp11/logicals.hpp
@@ -48,7 +48,8 @@ typedef r_vector<Rboolean> logicals;
 namespace writable {
 
 template <>
-inline typename r_vector<Rboolean>::proxy& r_vector<Rboolean>::proxy::operator=(
+template <>
+inline typename r_vector<Rboolean>::proxy& r_vector<Rboolean>::proxy::operator=<Rboolean>(
     const Rboolean& rhs) {
   if (is_altrep_) {
     SET_LOGICAL_ELT(data_, index_, rhs);
@@ -56,6 +57,13 @@ inline typename r_vector<Rboolean>::proxy& r_vector<Rboolean>::proxy::operator=(
     *p_ = rhs;
   }
   return *this;
+}
+
+template <>
+template <>
+inline typename r_vector<Rboolean>::proxy& r_vector<Rboolean>::proxy::operator=<bool>(
+  const bool& rhs) {
+  return operator=(rhs ? TRUE : FALSE);
 }
 
 template <>

--- a/inst/include/cpp11/r_vector.hpp
+++ b/inst/include/cpp11/r_vector.hpp
@@ -223,7 +223,8 @@ class r_vector : public cpp11::r_vector<T> {
    public:
     proxy(SEXP data, const R_xlen_t index, T* const p, bool is_altrep);
 
-    proxy& operator=(const T& rhs);
+    template <typename U>
+    proxy& operator=(const U& rhs);
     proxy& operator+=(const T& rhs);
     proxy& operator-=(const T& rhs);
     proxy& operator*=(const T& rhs);

--- a/inst/include/cpp11/raws.hpp
+++ b/inst/include/cpp11/raws.hpp
@@ -52,7 +52,8 @@ typedef r_vector<uint8_t> raws;
 namespace writable {
 
 template <>
-inline typename r_vector<uint8_t>::proxy& r_vector<uint8_t>::proxy::operator=(
+template <>
+inline typename r_vector<uint8_t>::proxy& r_vector<uint8_t>::proxy::operator=<uint8_t>(
     const uint8_t& rhs) {
   if (is_altrep_) {
     // NOPROTECT: likely too costly to unwind protect every set elt

--- a/inst/include/cpp11/strings.hpp
+++ b/inst/include/cpp11/strings.hpp
@@ -49,7 +49,8 @@ typedef r_vector<r_string> strings;
 namespace writable {
 
 template <>
-inline typename r_vector<r_string>::proxy& r_vector<r_string>::proxy::operator=(
+template <>
+inline typename r_vector<r_string>::proxy& r_vector<r_string>::proxy::operator=<r_string>(
     const r_string& rhs) {
   unwind_protect([&] { SET_STRING_ELT(data_, index_, rhs); });
   return *this;


### PR DESCRIPTION
closes #56

``` r
cpp11::cpp_function('
cpp11::writable::logicals bools(){ 
  cpp11::writable::logicals x(1);
  x[0] = true;
  return x;
  } 
', quiet = FALSE)
#> clang++ -mmacosx-version-min=10.13 -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I/Users/romainfrancois/.R/library/4.0/cpp11/include  -I/usr/local/include   -fPIC  -Wall -O3 -Wall -Wimplicit-int-float-conversion -c /private/var/folders/4b/hn4fq98s6810s4ccv2f9hm2h0000gn/T/RtmpHcARkQ/file494f394b9440/src/code_0.cpp -o /private/var/folders/4b/hn4fq98s6810s4ccv2f9hm2h0000gn/T/RtmpHcARkQ/file494f394b9440/src/code_0.o
#> clang++ -mmacosx-version-min=10.13 -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I/Users/romainfrancois/.R/library/4.0/cpp11/include  -I/usr/local/include   -fPIC  -Wall -O3 -Wall -Wimplicit-int-float-conversion -c /private/var/folders/4b/hn4fq98s6810s4ccv2f9hm2h0000gn/T/RtmpHcARkQ/file494f394b9440/src/cpp11.cpp -o /private/var/folders/4b/hn4fq98s6810s4ccv2f9hm2h0000gn/T/RtmpHcARkQ/file494f394b9440/src/cpp11.o
#> clang++ -mmacosx-version-min=10.13 -std=gnu++11 -dynamiclib -Wl,-headerpad_max_install_names -undefined dynamic_lookup -single_module -multiply_defined suppress -L/Library/Frameworks/R.framework/Resources/lib -L/usr/local/lib -o /private/var/folders/4b/hn4fq98s6810s4ccv2f9hm2h0000gn/T/RtmpHcARkQ/file494f394b9440/src/code_0.so /private/var/folders/4b/hn4fq98s6810s4ccv2f9hm2h0000gn/T/RtmpHcARkQ/file494f394b9440/src/code_0.o /private/var/folders/4b/hn4fq98s6810s4ccv2f9hm2h0000gn/T/RtmpHcARkQ/file494f394b9440/src/cpp11.o -F/Library/Frameworks/R.framework/.. -framework R -Wl,-framework -Wl,CoreFoundation
bools()
#> [1] TRUE
```

<sup>Created on 2020-07-24 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>

Other things could be useful, e.g. `cpp11::writable::doubles::operator=<int>` . 

The `list` one could be magical and go though `as_cpp<U>` but that might be good to leave it as explicit with `SEXP` 

