### PR TITLE
explicit conversion

### DIFF
--- a/inst/include/cpp11/as.hpp
+++ b/inst/include/cpp11/as.hpp
@@ -18,7 +18,7 @@ using is_constructible_from_sexp =
 
 template <typename T>
 is_constructible_from_sexp<T> as_cpp(SEXP from) {
-  return from;
+  return T(from);
 }
 
 template <typename T>


### PR DESCRIPTION
I believe this is required when `T` declares the constructor taking a `SEXP` as explicit. 