### PR TITLE
+ list::const_iterator::operator*

### DIFF
--- a/cpp11test/src/test-list.cpp
+++ b/cpp11test/src/test-list.cpp
@@ -57,4 +57,13 @@ context("list-C++") {
 
     expect_true(Rf_inherits(x, "data.frame"));
   }
+
+  test_that("list::iterator uses VECTOR_ELT") {
+    cpp11::writable::list x({
+      cpp11::writable::integers({1, 2})
+    });
+    cpp11::integers first(*x.begin());
+    expect_true(first[0] == 1);
+    expect_true(first[1] == 2);
+  }
 }

--- a/inst/include/cpp11/list.hpp
+++ b/inst/include/cpp11/list.hpp
@@ -50,6 +50,11 @@ inline void r_vector<SEXP>::const_iterator::fill_buf(R_xlen_t) {
   return;
 }
 
+template <>
+inline SEXP r_vector<SEXP>::const_iterator::operator*() {
+  return VECTOR_ELT(data_->data(), pos_);
+}
+
 typedef r_vector<SEXP> list;
 
 namespace writable {


### PR DESCRIPTION
modeled after `r_vector<r_string>::const_iterator::operator*`. 

This would otherwise fail as `*it` would give a `nullptr`

``` r
cpp11::cpp_function('SEXP premier(cpp11::list x) {
  auto it = x.begin(); 
  return *it;
}', quiet = FALSE)
#> clang++ -mmacosx-version-min=10.13 -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I/Users/romainfrancois/.R/library/4.0/cpp11/include  -I/usr/local/include   -fPIC  -Wall -O3 -Wall -Wimplicit-int-float-conversion -c /private/var/folders/4b/hn4fq98s6810s4ccv2f9hm2h0000gn/T/Rtmp3hU7Um/file11df6d2e2e10/src/code_0.cpp -o /private/var/folders/4b/hn4fq98s6810s4ccv2f9hm2h0000gn/T/Rtmp3hU7Um/file11df6d2e2e10/src/code_0.o
#> clang++ -mmacosx-version-min=10.13 -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I/Users/romainfrancois/.R/library/4.0/cpp11/include  -I/usr/local/include   -fPIC  -Wall -O3 -Wall -Wimplicit-int-float-conversion -c /private/var/folders/4b/hn4fq98s6810s4ccv2f9hm2h0000gn/T/Rtmp3hU7Um/file11df6d2e2e10/src/cpp11.cpp -o /private/var/folders/4b/hn4fq98s6810s4ccv2f9hm2h0000gn/T/Rtmp3hU7Um/file11df6d2e2e10/src/cpp11.o
#> clang++ -mmacosx-version-min=10.13 -std=gnu++11 -dynamiclib -Wl,-headerpad_max_install_names -undefined dynamic_lookup -single_module -multiply_defined suppress -L/Library/Frameworks/R.framework/Resources/lib -L/usr/local/lib -o /private/var/folders/4b/hn4fq98s6810s4ccv2f9hm2h0000gn/T/Rtmp3hU7Um/file11df6d2e2e10/src/code_0.so /private/var/folders/4b/hn4fq98s6810s4ccv2f9hm2h0000gn/T/Rtmp3hU7Um/file11df6d2e2e10/src/code_0.o /private/var/folders/4b/hn4fq98s6810s4ccv2f9hm2h0000gn/T/Rtmp3hU7Um/file11df6d2e2e10/src/cpp11.o -F/Library/Frameworks/R.framework/.. -framework R -Wl,-framework -Wl,CoreFoundation

premier(list(1, 1:10, letters))
#> [1] 1
```

<sup>Created on 2020-07-27 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>