### PR TITLE
r_string(char[N]) constructor

### DIFF
--- a/inst/include/cpp11/r_string.hpp
+++ b/inst/include/cpp11/r_string.hpp
@@ -16,6 +16,9 @@ class r_string {
   r_string(const char* data) : data_(safe[Rf_mkCharCE](data, CE_UTF8)) {}
   r_string(const std::string& data) : data_(safe[Rf_mkCharCE](data.c_str(), CE_UTF8)) {}
 
+  template <int N>
+  r_string(char data [N]) : data_(safe[Rf_mkCharLenCE](data, N, CE_UTF8)) {}
+
   operator SEXP() const { return data_; }
   operator sexp() const { return data_; }
   operator std::string() const {


### PR DESCRIPTION
This is an. experiment to see if this still gets this error on actions: https://github.com/r-lib/cpp11/runs/915320770#step:10:116

```
##[error]Error: package or namespace load failed for ‘cpp11test’ in dyn.load(file, DLLpath = DLLpath, ...):
117
ERROR: loading failed
118
 unable to load shared object '/Users/runner/work/_temp/Library/00LOCK-cpp11test/00new/cpp11test/libs/cpp11test.so':
119
  dlopen(/Users/runner/work/_temp/Library/00LOCK-cpp11test/00new/cpp11test/libs/cpp11test.so, 6): Symbol not found: __ZN5cpp118writable8r_vectorINS_8r_stringEE5proxyaSIA2_cEERS4_RKT_
120
  Referenced from: /Users/runner/work/_temp/Library/00LOCK-cpp11test/00new/cpp11test/libs/cpp11test.so
121
  Expected in: flat namespace
122
 in /Users/runner/work/_temp/Library/00LOCK-cpp11test/00new/cpp11test/libs/cpp11test.so
```

with: 

```
$ c++filt __ZN5cpp118writable8r_vectorINS_8r_stringEE5proxyaSIA2_cEERS4_RKT_
cpp11::writable::r_vector<cpp11::r_string>::proxy& cpp11::writable::r_vector<cpp11::r_string>::proxy::operator=<char [2]>(char const (&) [2])
```


