### PR TITLE
remove unwind_protect_sexp

### DIFF
--- a/cpp11test/src/safe.cpp
+++ b/cpp11test/src/safe.cpp
@@ -12,7 +12,7 @@
     // Rf_error("R error"); // This will not call dtors
     // throw std::runtime_error("C++ error");
     // cpp11::unwind_protect([&]() { Rf_error("R error"); });
-    SEXP out = cpp11::unwind_protect_sexp([&]() { return Rf_allocVector(REALSXP, 1); });
+    SEXP out = cpp11::unwind_protect([&] { return Rf_allocVector(REALSXP, 1); });
 
     return out;
   }

--- a/cpp11test/src/test-protect.cpp
+++ b/cpp11test/src/test-protect.cpp
@@ -4,7 +4,7 @@
 #ifdef HAS_UNWIND_PROTECT
 context("unwind_protect-C++") {
   test_that("unwind_protect works if there is no error") {
-    SEXP out = PROTECT(cpp11::unwind_protect_sexp([&] {
+    SEXP out = PROTECT(cpp11::unwind_protect([&] {
       out = PROTECT(Rf_allocVector(REALSXP, 1));
       REAL(out)[0] = 1;
       UNPROTECT(1);
@@ -18,7 +18,7 @@ context("unwind_protect-C++") {
   }
   test_that("unwind_protect throws a C++ exception if there is an R error") {
     SEXP out;
-    expect_error_as(cpp11::unwind_protect_sexp([&] {
+    expect_error_as(cpp11::unwind_protect([&] {
                       out = PROTECT(Rf_allocVector(REALSXP, -1));
                       REAL(out)[0] = 1;
                       UNPROTECT(1);


### PR DESCRIPTION
The explicit suffix is not necessary since `unwind_protect` is overloaded to handle both return types

https://github.com/r-lib/cpp11/pull/54#discussion_r461597780