### PR TITLE
capture parameter pack as a tuple to work around gcc4.8

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cpp11 (development version)
 
+* cpp11 is now able to compile on gcc 4.8.5 (#69, @bkietz)
+
 * `as_cpp<E>()` now allows enumeration `E` (#52, @bkietz)
 
 * `writable::logicals::operator=()` now allows C++ boolean values (#57, @romainfrancois)

--- a/inst/include/cpp11/protect.hpp
+++ b/inst/include/cpp11/protect.hpp
@@ -242,7 +242,7 @@ inline void check_user_interrupt() { safe[R_CheckUserInterrupt](); }
 
 template <typename... Args>
 void stop [[noreturn]] (const char* fmt, Args... args) {
-  unwind_protect([&] { Rf_error(fmt, args...); });
+  safe[Rf_error](fmt, args...);
   // Compiler hint to allow [[noreturn]] attribute; this is never executed since Rf_error
   // will longjmp
   throw std::runtime_error("stop()");
@@ -250,7 +250,7 @@ void stop [[noreturn]] (const char* fmt, Args... args) {
 
 template <typename... Args>
 void stop [[noreturn]] (const std::string& fmt, Args... args) {
-  unwind_protect([&] { Rf_error(fmt.c_str(), args...); });
+  safe[Rf_error](fmt.c_str(), args...);
   // Compiler hint to allow [[noreturn]] attribute; this is never executed since Rf_error
   // will longjmp
   throw std::runtime_error("stop()");


### PR DESCRIPTION
fixes #69

repro: https://wandbox.org/permlink/po7niLIoJ9HgJ74p
fixed: https://wandbox.org/permlink/RTg6mAArF13XyuRU

There are more sophisticated/general implementations of make_index_sequence/apply if desired 