### PR TITLE
handle enum with underlying type char

### DIFF
--- a/cpp11test/src/test-as.cpp
+++ b/cpp11test/src/test-as.cpp
@@ -90,6 +90,19 @@ context("as_cpp-C++") {
     UNPROTECT(1);
   }
 
+  test_that("as_cpp<enum:char>(INTSEXP)") {
+    enum class Response: char { YES, NO, MAYBE };
+    SEXP r = PROTECT(Rf_allocVector(INTSXP, 1));
+
+    for (Response e : {Response::YES, Response::NO, Response::MAYBE, static_cast<Response>(42)}) {
+      INTEGER(r)[0] = static_cast<int>(e);
+      auto x = cpp11::as_cpp<Response>(r);
+      expect_true(x == e);
+    }
+
+    UNPROTECT(1);
+  }
+
   test_that("as_cpp<double>(REALSXP)") {
     SEXP r = PROTECT(Rf_allocVector(REALSXP, 1));
     REAL(r)[0] = 1.2;

--- a/inst/include/cpp11/as.hpp
+++ b/inst/include/cpp11/as.hpp
@@ -96,7 +96,12 @@ enable_if_integral<T, T> as_cpp(SEXP from) {
 template <typename E>
 enable_if_enum<E, E> as_cpp(SEXP from) {
   if (Rf_isInteger(from)) {
-    return static_cast<E>(as_cpp<typename std::underlying_type<E>::type>(from));
+    using Type = typename std::conditional<
+      std::is_same<char, typename std::underlying_type<E>::type>::value,
+      int,
+      typename std::underlying_type<E>::type
+    >::type;
+    return static_cast<E>(as_cpp<Type>(from));
   }
 
   stop("Expected single integer value");

--- a/inst/include/cpp11/as.hpp
+++ b/inst/include/cpp11/as.hpp
@@ -96,12 +96,13 @@ enable_if_integral<T, T> as_cpp(SEXP from) {
 template <typename E>
 enable_if_enum<E, E> as_cpp(SEXP from) {
   if (Rf_isInteger(from)) {
-    using Type = typename std::conditional<
-      std::is_same<char, typename std::underlying_type<E>::type>::value,
-      int,
-      typename std::underlying_type<E>::type
+    using underlying_type = typename std::underlying_type<E>::type;
+    using int_type = typename std::conditional<
+      std::is_same<char, underlying_type>::value,
+      int, // as_cpp<char> would trigger undesired string conversions
+      underlying_type
     >::type;
-    return static_cast<E>(as_cpp<Type>(from));
+    return static_cast<E>(as_cpp<int_type>(from));
   }
 
   stop("Expected single integer value");


### PR DESCRIPTION
Follow up to #65 

Some enum classes in arrow have `char` as their underlying type and this avoids `as_cpp<char>()` which apparently doesn't compile. 

closes #73