### PR TITLE
workaround mangle collision between decltype(Rf_error) and decltype(Rf_warning)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ cpp11test/src/*.so
 compile_flags.txt
 inst/doc
 vignettes/*_cache
+compile_commands.json

--- a/cpp11test/src/test-protect.cpp
+++ b/cpp11test/src/test-protect.cpp
@@ -37,6 +37,13 @@ context("unwind_protect-C++") {
     UNPROTECT(1);
   }
 
+  test_that("stop throws an unwind_exception") {
+    expect_error_as(cpp11::stop("error"), cpp11::unwind_exception);
+    expect_error_with(cpp11::stop("error"), "error");
+    expect_error_as(cpp11::stop("error: %s", "message"), cpp11::unwind_exception);
+    expect_error_with(cpp11::stop("error: %s", "message"), "error: message");
+  }
+
   test_that("safe wraps R functions and works if there is an R error") {
     expect_error_as(cpp11::safe[Rf_allocVector](REALSXP, -1), cpp11::unwind_exception);
   }

--- a/cpp11test/src/test-protect.cpp
+++ b/cpp11test/src/test-protect.cpp
@@ -39,9 +39,7 @@ context("unwind_protect-C++") {
 
   test_that("stop throws an unwind_exception") {
     expect_error_as(cpp11::stop("error"), cpp11::unwind_exception);
-    expect_error_with(cpp11::stop("error"), "error");
     expect_error_as(cpp11::stop("error: %s", "message"), cpp11::unwind_exception);
-    expect_error_with(cpp11::stop("error: %s", "message"), "error: message");
   }
 
   test_that("safe wraps R functions and works if there is an R error") {


### PR DESCRIPTION
I also cleaned up the signatures of detail:: functions, hopefully it's more readable