### PR TITLE
Preserved list refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ cpp11test/src/*.so
 compile_flags.txt
 inst/doc
 vignettes/*_cache
+compile_commands.json

--- a/R/utils.R
+++ b/R/utils.R
@@ -67,3 +67,5 @@ is_interactive <- function() {
     }
     interactive()
 }
+
+`.preserve_list` <- pairlist(NA, NA)

--- a/R/utils.R
+++ b/R/utils.R
@@ -67,5 +67,3 @@ is_interactive <- function() {
     }
     interactive()
 }
-
-`.preserve_list` <- pairlist(NA, NA)

--- a/cpp11test/src/protect.cpp
+++ b/cpp11test/src/protect.cpp
@@ -18,8 +18,8 @@
 
 [[cpp11::register]] void protect_one_cpp11_(SEXP x, int n) {
   for (R_xlen_t i = 0; i < n; ++i) {
-    SEXP p = cpp11::protect_sexp(x);
-    cpp11::release_protect(p);
+    SEXP p = cpp11::preserved.insert(x);
+    cpp11::preserved.release(p);
   }
 }
 
@@ -63,12 +63,12 @@
 [[cpp11::register]] void protect_many_cpp11_(int n) {
   std::vector<SEXP> res;
   for (R_xlen_t i = 0; i < n; ++i) {
-    res.push_back(cpp11::protect_sexp(Rf_ScalarInteger(n)));
+    res.push_back(cpp11::preserved.insert(Rf_ScalarInteger(n)));
   }
 
   for (R_xlen_t i = n - 1; i >= 0; --i) {
     SEXP x = res[i];
-    cpp11::release_protect(x);
+    cpp11::preserved.release(x);
     res.pop_back();
   }
 }

--- a/cpp11test/src/test-sexp.cpp
+++ b/cpp11test/src/test-sexp.cpp
@@ -15,6 +15,7 @@ context("sexp-C++") {
 
     expect_true(Rf_inherits(out, "data.frame"));
   }
+
   test_that("scalar constructors work") {
     using namespace cpp11::literals;
     cpp11::writable::list out({

--- a/inst/include/cpp11/doubles.hpp
+++ b/inst/include/cpp11/doubles.hpp
@@ -79,7 +79,7 @@ template <>
 inline r_vector<double>::r_vector(std::initializer_list<named_arg> il)
     : cpp11::r_vector<double>(safe[Rf_allocVector](REALSXP, il.size())),
       capacity_(il.size()) {
-  protect_ = protect_sexp(data_);
+  protect_ = preserved.insert(data_);
   int n_protected = 0;
 
   try {
@@ -95,7 +95,7 @@ inline r_vector<double>::r_vector(std::initializer_list<named_arg> il)
       UNPROTECT(n_protected);
     });
   } catch (const unwind_exception& e) {
-    release_protect(protect_);
+    preserved.release(protect_);
     UNPROTECT(n_protected);
     throw e;
   }
@@ -106,8 +106,8 @@ inline void r_vector<double>::reserve(R_xlen_t new_capacity) {
   data_ = data_ == R_NilValue ? safe[Rf_allocVector](REALSXP, new_capacity)
                               : safe[Rf_xlengthgets](data_, new_capacity);
   SEXP old_protect = protect_;
-  protect_ = protect_sexp(data_);
-  release_protect(old_protect);
+  protect_ = preserved.insert(data_);
+  preserved.release(old_protect);
 
   data_p_ = REAL(data_);
   capacity_ = new_capacity;

--- a/inst/include/cpp11/list.hpp
+++ b/inst/include/cpp11/list.hpp
@@ -5,7 +5,7 @@
 #include "cpp11/R.hpp"                // for SEXP, SEXPREC, SET_VECTOR_ELT
 #include "cpp11/attribute_proxy.hpp"  // for attribute_proxy
 #include "cpp11/named_arg.hpp"        // for named_arg
-#include "cpp11/protect.hpp"          // for protect_sexp, release_protect
+#include "cpp11/protect.hpp"          // for protect_sexp, preserved.release
 #include "cpp11/r_string.hpp"         // for r_string
 #include "cpp11/r_vector.hpp"         // for r_vector, r_vector<>::proxy
 #include "cpp11/sexp.hpp"             // for sexp
@@ -75,7 +75,7 @@ template <>
 inline r_vector<SEXP>::r_vector(std::initializer_list<SEXP> il)
     : cpp11::r_vector<SEXP>(safe[Rf_allocVector](VECSXP, il.size())),
       capacity_(il.size()) {
-  protect_ = protect_sexp(data_);
+  protect_ = preserved.insert(data_);
   auto it = il.begin();
   for (R_xlen_t i = 0; i < capacity_; ++i, ++it) {
     SET_VECTOR_ELT(data_, i, *it);
@@ -86,7 +86,7 @@ template <>
 inline r_vector<SEXP>::r_vector(std::initializer_list<named_arg> il)
     : cpp11::r_vector<SEXP>(safe[Rf_allocVector](VECSXP, il.size())),
       capacity_(il.size()) {
-  protect_ = protect_sexp(data_);
+  protect_ = preserved.insert(data_);
   int n_protected = 0;
 
   try {
@@ -102,7 +102,7 @@ inline r_vector<SEXP>::r_vector(std::initializer_list<named_arg> il)
       UNPROTECT(n_protected);
     });
   } catch (const unwind_exception& e) {
-    release_protect(protect_);
+    preserved.release(protect_);
     UNPROTECT(n_protected);
     throw e;
   }
@@ -114,8 +114,8 @@ inline void r_vector<SEXP>::reserve(R_xlen_t new_capacity) {
                               : safe[Rf_xlengthgets](data_, new_capacity);
 
   SEXP old_protect = protect_;
-  protect_ = protect_sexp(data_);
-  release_protect(old_protect);
+  protect_ = preserved.insert(data_);
+  preserved.release(old_protect);
 
   capacity_ = new_capacity;
 }

--- a/inst/include/cpp11/list.hpp
+++ b/inst/include/cpp11/list.hpp
@@ -5,7 +5,7 @@
 #include "cpp11/R.hpp"                // for SEXP, SEXPREC, SET_VECTOR_ELT
 #include "cpp11/attribute_proxy.hpp"  // for attribute_proxy
 #include "cpp11/named_arg.hpp"        // for named_arg
-#include "cpp11/protect.hpp"          // for protect_sexp, preserved.release
+#include "cpp11/protect.hpp"          // for preserved
 #include "cpp11/r_string.hpp"         // for r_string
 #include "cpp11/r_vector.hpp"         // for r_vector, r_vector<>::proxy
 #include "cpp11/sexp.hpp"             // for sexp

--- a/inst/include/cpp11/protect.hpp
+++ b/inst/include/cpp11/protect.hpp
@@ -288,8 +288,18 @@ static struct {
       // The .preserve_list singleton is a member of cpp11::: and is managed by the R
       // runtime. It cannot be constructed a header since many translation units may be
       // compiled, resulting in unrelated instances of each static variable.
-      SEXP ns = safe[Rf_findVarInFrame](R_NamespaceRegistry, safe[Rf_install]("cpp11"));
-      list_singleton = safe[Rf_findVar](safe[Rf_install](".preserve_list"), ns);
+
+      // FIXME how can we create the cpp11 namespace when it doesn't already exist?
+      SEXP list_singleton_sym = safe[Rf_install](".cpp11_preserve_list");
+
+      list_singleton = safe[Rf_findVarInFrame](R_GlobalEnv, list_singleton_sym);
+
+      if (list_singleton == R_UnboundValue) {
+        list_singleton = PROTECT(Rf_cons(R_NilValue, R_NilValue));
+        R_PreserveObject(list_singleton);
+        UNPROTECT(1);
+        safe[Rf_defineVar](list_singleton_sym, list_singleton, R_GlobalEnv);
+      }
     }
 
     return list_singleton;

--- a/inst/include/cpp11/protect.hpp
+++ b/inst/include/cpp11/protect.hpp
@@ -281,6 +281,18 @@ static struct {
   }
 
  private:
+  static void set_option(SEXP name, SEXP value) {
+    SEXP opt = SYMVALUE(safe[Rf_install](".Options"));
+    SEXP t = opt;
+    while (CDR(t) != R_NilValue) {
+      t = CDR(t);
+    }
+    SETCDR(t, Rf_allocList(1));
+    opt = CDR(t);
+    SET_TAG(opt, name);
+    SETCAR(opt, value);
+  }
+
   static SEXP get_preserve_list() {
     static SEXP list_singleton = R_NilValue;
 
@@ -290,15 +302,14 @@ static struct {
       // compiled, resulting in unrelated instances of each static variable.
 
       // FIXME how can we create the cpp11 namespace when it doesn't already exist?
-      SEXP list_singleton_sym = safe[Rf_install](".cpp11_preserve_list");
+      SEXP list_singleton_sym = safe[Rf_install]("cpp11_preserve_list");
 
-      list_singleton = safe[Rf_findVarInFrame](R_GlobalEnv, list_singleton_sym);
+      list_singleton = safe[Rf_GetOption1](list_singleton_sym);
 
-      if (list_singleton == R_UnboundValue) {
-        list_singleton = PROTECT(Rf_cons(R_NilValue, R_NilValue));
+      if (list_singleton == R_NilValue) {
+        list_singleton = Rf_cons(R_NilValue, R_NilValue);
         R_PreserveObject(list_singleton);
-        UNPROTECT(1);
-        safe[Rf_defineVar](list_singleton_sym, list_singleton, R_GlobalEnv);
+        set_option(list_singleton_sym, list_singleton);
       }
     }
 

--- a/inst/include/cpp11/r_vector.hpp
+++ b/inst/include/cpp11/r_vector.hpp
@@ -766,7 +766,9 @@ inline r_vector<T>::r_vector(const r_vector<T>& rhs)
 
 template <typename T>
 inline r_vector<T>::r_vector(r_vector<T>&& rhs)
-    : cpp11::r_vector<T>(rhs), protect_(preserved.insert(data_)), capacity_(rhs.capacity_) {
+    : cpp11::r_vector<T>(rhs),
+      protect_(preserved.insert(data_)),
+      capacity_(rhs.capacity_) {
   rhs.data_ = R_NilValue;
   rhs.protect_ = R_NilValue;
 }

--- a/inst/include/cpp11/r_vector.hpp
+++ b/inst/include/cpp11/r_vector.hpp
@@ -15,7 +15,7 @@
 
 #include "cpp11/R.hpp"                // for R_xlen_t, SEXP, SEXPREC, Rf_xle...
 #include "cpp11/attribute_proxy.hpp"  // for attribute_proxy
-#include "cpp11/protect.hpp"          // for protect_sexp, release_protect
+#include "cpp11/protect.hpp"          // for preserved
 #include "cpp11/r_string.hpp"         // for r_string
 #include "cpp11/sexp.hpp"             // for sexp
 
@@ -80,12 +80,12 @@ class r_vector {
     SEXP old_protect = protect_;
 
     data_ = rhs.data_;
-    protect_ = protect_sexp(data_);
+    protect_ = preserved.insert(data_);
     is_altrep_ = rhs.is_altrep_;
     data_p_ = rhs.data_p_;
     length_ = rhs.length_;
 
-    release_protect(old_protect);
+    preserved.release(old_protect);
 
     return *this;
   };
@@ -94,12 +94,12 @@ class r_vector {
     SEXP old_protect = protect_;
 
     data_ = rhs.data_;
-    protect_ = protect_sexp(data_);
+    protect_ = preserved.insert(data_);
     is_altrep_ = rhs.is_altrep_;
     data_p_ = rhs.data_p_;
     length_ = rhs.length_;
 
-    release_protect(old_protect);
+    preserved.release(old_protect);
   };
 
   bool is_altrep() const;
@@ -178,7 +178,7 @@ class r_vector {
 
   const_iterator find(const r_string& name) const;
 
-  ~r_vector() { release_protect(protect_); }
+  ~r_vector() { preserved.release(protect_); }
 
  private:
   SEXP data_ = R_NilValue;
@@ -359,7 +359,7 @@ class r_vector : public cpp11::r_vector<T> {
 template <typename T>
 inline r_vector<T>::r_vector(const SEXP data)
     : data_(valid_type(data)),
-      protect_(protect_sexp(data)),
+      protect_(preserved.insert(data)),
       is_altrep_(ALTREP(data)),
       data_p_(get_p(ALTREP(data), data)),
       length_(Rf_xlength(data)) {}
@@ -367,7 +367,7 @@ inline r_vector<T>::r_vector(const SEXP data)
 template <typename T>
 inline r_vector<T>::r_vector(const SEXP data, bool is_altrep)
     : data_(valid_type(data)),
-      protect_(protect_sexp(data)),
+      protect_(preserved.insert(data)),
       is_altrep_(is_altrep),
       data_p_(get_p(is_altrep, data)),
       length_(Rf_xlength(data)) {}
@@ -630,23 +630,23 @@ inline typename r_vector<T>::iterator r_vector<T>::end() const {
 template <typename T>
 inline r_vector<T>::r_vector(const SEXP& data)
     : cpp11::r_vector<T>(safe[Rf_shallow_duplicate](data)),
-      protect_(protect_sexp(data_)),
+      protect_(preserved.insert(data_)),
       capacity_(length_) {}
 
 template <typename T>
 inline r_vector<T>::r_vector(const SEXP& data, bool is_altrep)
     : cpp11::r_vector<T>(safe[Rf_shallow_duplicate](data), is_altrep),
-      protect_(protect_sexp(data_)),
+      protect_(preserved.insert(data_)),
       capacity_(length_) {}
 
 template <typename T>
 inline r_vector<T>::r_vector(SEXP&& data)
-    : cpp11::r_vector<T>(data), protect_(protect_sexp(data_)), capacity_(length_) {}
+    : cpp11::r_vector<T>(data), protect_(preserved.insert(data_)), capacity_(length_) {}
 
 template <typename T>
 inline r_vector<T>::r_vector(SEXP&& data, bool is_altrep)
     : cpp11::r_vector<T>(data, is_altrep),
-      protect_(protect_sexp(data_)),
+      protect_(preserved.insert(data_)),
       capacity_(length_) {}
 
 template <typename T>
@@ -678,7 +678,7 @@ inline r_vector<T>::r_vector(R_xlen_t size) : r_vector() {
 
 template <typename T>
 inline r_vector<T>::~r_vector() {
-  release_protect(protect_);
+  preserved.release(protect_);
 }
 
 #ifdef LONG_VECTOR_SUPPORT
@@ -761,12 +761,12 @@ inline typename r_vector<T>::iterator r_vector<T>::find(const r_string& name) co
 template <typename T>
 inline r_vector<T>::r_vector(const r_vector<T>& rhs)
     : cpp11::r_vector<T>(safe[Rf_shallow_duplicate](rhs)),
-      protect_(protect_sexp(data_)),
+      protect_(preserved.insert(data_)),
       capacity_(rhs.capacity_) {}
 
 template <typename T>
 inline r_vector<T>::r_vector(r_vector<T>&& rhs)
-    : cpp11::r_vector<T>(rhs), protect_(protect_sexp(data_)), capacity_(rhs.capacity_) {
+    : cpp11::r_vector<T>(rhs), protect_(preserved.insert(data_)), capacity_(rhs.capacity_) {
   rhs.data_ = R_NilValue;
   rhs.protect_ = R_NilValue;
 }
@@ -774,7 +774,7 @@ inline r_vector<T>::r_vector(r_vector<T>&& rhs)
 template <typename T>
 inline r_vector<T>::r_vector(const cpp11::r_vector<T>& rhs)
     : cpp11::r_vector<T>(safe[Rf_shallow_duplicate](rhs)),
-      protect_(protect_sexp(data_)),
+      protect_(preserved.insert(data_)),
       capacity_(rhs.length_) {}
 
 // We don't release the old object until the end in case we throw an exception
@@ -790,9 +790,9 @@ inline r_vector<T>& r_vector<T>::operator=(const r_vector<T>& rhs) {
   auto old_protect = protect_;
 
   data_ = safe[Rf_shallow_duplicate](rhs.data_);
-  protect_ = protect_sexp(data_);
+  protect_ = preserved.insert(data_);
 
-  release_protect(old_protect);
+  preserved.release(old_protect);
 
   capacity_ = rhs.capacity_;
 
@@ -810,9 +810,9 @@ inline r_vector<T>& r_vector<T>::operator=(r_vector<T>&& rhs) {
   SEXP old_protect = protect_;
 
   data_ = rhs.data_;
-  protect_ = protect_sexp(data_);
+  protect_ = preserved.insert(data_);
 
-  release_protect(old_protect);
+  preserved.release(old_protect);
 
   capacity_ = rhs.capacity_;
 

--- a/inst/include/cpp11/raws.hpp
+++ b/inst/include/cpp11/raws.hpp
@@ -8,7 +8,7 @@
 #include "cpp11/R.hpp"                // for RAW, SEXP, SEXPREC, Rf_allocVector
 #include "cpp11/attribute_proxy.hpp"  // for attribute_proxy
 #include "cpp11/named_arg.hpp"        // for named_arg
-#include "cpp11/protect.hpp"          // for protect_sexp, preserved.release
+#include "cpp11/protect.hpp"          // for preserved
 #include "cpp11/r_vector.hpp"         // for r_vector, r_vector<>::proxy
 #include "cpp11/sexp.hpp"             // for sexp
 

--- a/inst/include/cpp11/strings.hpp
+++ b/inst/include/cpp11/strings.hpp
@@ -7,7 +7,7 @@
 #include "cpp11/as.hpp"               // for as_sexp
 #include "cpp11/attribute_proxy.hpp"  // for attribute_proxy
 #include "cpp11/named_arg.hpp"        // for named_arg
-#include "cpp11/protect.hpp"          // for preserved.insert, unwind_protect
+#include "cpp11/protect.hpp"          // for preserved
 #include "cpp11/r_string.hpp"         // for r_string
 #include "cpp11/r_vector.hpp"         // for r_vector, r_vector<>::proxy
 #include "cpp11/sexp.hpp"             // for sexp

--- a/inst/include/cpp11/strings.hpp
+++ b/inst/include/cpp11/strings.hpp
@@ -7,7 +7,7 @@
 #include "cpp11/as.hpp"               // for as_sexp
 #include "cpp11/attribute_proxy.hpp"  // for attribute_proxy
 #include "cpp11/named_arg.hpp"        // for named_arg
-#include "cpp11/protect.hpp"          // for protect_sexp, unwind_protect
+#include "cpp11/protect.hpp"          // for preserved.insert, unwind_protect
 #include "cpp11/r_string.hpp"         // for r_string
 #include "cpp11/r_vector.hpp"         // for r_vector, r_vector<>::proxy
 #include "cpp11/sexp.hpp"             // for sexp
@@ -91,7 +91,7 @@ inline SEXP alloc_if_charsxp(const SEXP data) {
 template <>
 inline r_vector<r_string>::r_vector(const SEXP& data)
     : cpp11::r_vector<r_string>(alloc_or_copy(data)),
-      protect_(protect_sexp(data_)),
+      protect_(preserved.insert(data_)),
       capacity_(length_) {
   if (TYPEOF(data) == CHARSXP) {
     SET_STRING_ELT(data_, 0, data);
@@ -101,7 +101,7 @@ inline r_vector<r_string>::r_vector(const SEXP& data)
 template <>
 inline r_vector<r_string>::r_vector(SEXP&& data)
     : cpp11::r_vector<r_string>(alloc_if_charsxp(data)),
-      protect_(protect_sexp(data_)),
+      protect_(preserved.insert(data_)),
       capacity_(length_) {
   if (TYPEOF(data) == CHARSXP) {
     SET_STRING_ELT(data_, 0, data);
@@ -124,7 +124,7 @@ template <>
 inline r_vector<r_string>::r_vector(std::initializer_list<named_arg> il)
     : cpp11::r_vector<r_string>(safe[Rf_allocVector](STRSXP, il.size())),
       capacity_(il.size()) {
-  protect_ = protect_sexp(data_);
+  protect_ = preserved.insert(data_);
   int n_protected = 0;
 
   try {
@@ -140,7 +140,7 @@ inline r_vector<r_string>::r_vector(std::initializer_list<named_arg> il)
       UNPROTECT(n_protected);
     });
   } catch (const unwind_exception& e) {
-    release_protect(protect_);
+    preserved.release(protect_);
     UNPROTECT(n_protected);
     throw e;
   }
@@ -152,8 +152,8 @@ inline void r_vector<r_string>::reserve(R_xlen_t new_capacity) {
                               : safe[Rf_xlengthgets](data_, new_capacity);
 
   SEXP old_protect = protect_;
-  protect_ = protect_sexp(data_);
-  release_protect(old_protect);
+  protect_ = preserved.insert(data_);
+  preserved.release(old_protect);
 
   capacity_ = new_capacity;
 }

--- a/tests/testthat/test-source.R
+++ b/tests/testthat/test-source.R
@@ -15,9 +15,9 @@ test_that("cpp_source works with the `code` parameter", {
       return total;
     }
     ', clean = TRUE)
-    on.exit(dyn.unload(dll_info[["path"]]))
+  on.exit(dyn.unload(dll_info[["path"]]))
 
-    expect_equal(num_odd(as.integer(c(1:10, 15, 23))), 7)
+  expect_equal(num_odd(as.integer(c(1:10, 15, 23))), 7)
 })
 
 test_that("cpp_source works with the `file` parameter", {

--- a/vignettes/internals.Rmd
+++ b/vignettes/internals.Rmd
@@ -115,8 +115,8 @@ cpp11 uses an idea proposed by [Luke Tierney](https://github.com/RcppCore/Rcpp/i
 Each node in the list uses the head (`CAR`) part to point to the previous node, and the `CDR` part to point to the next node. The `TAG` is used to point to the object being protected.
 The head and tail of the list have `R_NilValue` as their `CAR` and `CDR` pointers respectively.
 
-Calling `protect_sexp()` with a regular R object will add a new node to the list and return a protect token corresponding to the node added.
-Calling `release_protect()` on this returned token will release the protection by unlinking the node from the linked list.
+Calling `preserved.insert()` with a regular R object will add a new node to the list and return a protect token corresponding to the node added.
+Calling `preserved.release()` on this returned token will release the protection by unlinking the node from the linked list.
 
 This scheme scales in O(1) time to release or insert an object vs O(N) or worse time with `R_PreserveObject()` / `R_ReleaseObject()`.
 
@@ -146,5 +146,5 @@ None of these options is perfect, here are some pros and cons for each.
 3. Was ruled out partially because the implementation would be somewhat tricky and more because performance would suffer greatly.
 4. is what we now do in cpp11. It leaks protected objects when there are R API errors.
 
-If packages are concerned about the leaked memory they can call `cpp11::release_existing_protections()` as needed to release the current protections for all objects managed by cpp11.
+If packages are concerned about the leaked memory they can call `cpp11::preserved.release_all()` as needed to release the current protections for all objects managed by cpp11.
 This is not done automatically because in some cases the protections should persist beyond the `.Call()` boundry, e.g. in vroom altrep objects for example.


### PR DESCRIPTION
- Renamed from `protect_sexp/release_protect/...` to `preserved.insert/preserved.release` to highlight the similarity in intent to `R_PreserveObject` and decrease the semantic overload of "protect"
- Moved the doubly-linked list of preserved objects from a static object in c++ named `cpp11::protect_list` to an internal in R named `cpp11:::.preserve_list`. This allows the list to be a singleton since any shared object we load will look up the same `cpp11:::.preserve_list`. By contrast a new c++ static variable will be instantiated for each translation unit we compile, resulting in multiple unrelated preserve_lists:
  ```r
  cpp11::cpp_function('SEXP protect_one(SEXP e) { cpp11::protect_sexp(e); return e; }')
  cpp11::cpp_function('int protected_count() { return Rf_length(cpp11::protect_list) - 1; }')
  for (i in 1:10) protect_one(i)
  protected_count() # 0, since it comes from a different translation unit from protect_one
  ```
- Inlined `cpp11::preserve()`
- `sexp& sexp::operator=(const sexp& rhs)` did not release its data before acquiring a new preservation token