### PR TITLE
special case as_cpp<SEXP>()

### DIFF
--- a/inst/include/cpp11/as.hpp
+++ b/inst/include/cpp11/as.hpp
@@ -18,9 +18,11 @@ using decay_t = typename std::decay<T>::type;
 
 template <typename T, typename R = void>
 using enable_if_constructible_from_sexp =
-    enable_if_t<(std::is_class<T>::value || std::is_same<T, SEXP>::value) &&
-                    std::is_constructible<T, SEXP>::value,
-                R>;
+    enable_if_t<std::is_class<T>::value && std::is_constructible<T, SEXP>::value, R>;
+
+template <typename T, typename R = void>
+using enable_if_is_sexp =
+    enable_if_t<std::is_same<T, SEXP>::value, R>;
 
 template <typename T, typename R = void>
 using enable_if_convertible_to_sexp = enable_if_t<std::is_convertible<T, SEXP>::value, R>;
@@ -64,6 +66,11 @@ inline bool is_convertable_without_loss_to_integer(double value) {
 template <typename T>
 enable_if_constructible_from_sexp<T, T> as_cpp(SEXP from) {
   return T(from);
+}
+
+template <typename T>
+enable_if_is_sexp<T, T> as_cpp(SEXP from) {
+  return from;
 }
 
 template <typename T>

--- a/inst/include/cpp11/as.hpp
+++ b/inst/include/cpp11/as.hpp
@@ -21,8 +21,7 @@ using enable_if_constructible_from_sexp =
     enable_if_t<std::is_class<T>::value && std::is_constructible<T, SEXP>::value, R>;
 
 template <typename T, typename R = void>
-using enable_if_is_sexp =
-    enable_if_t<std::is_same<T, SEXP>::value, R>;
+using enable_if_is_sexp = enable_if_t<std::is_same<T, SEXP>::value, R>;
 
 template <typename T, typename R = void>
 using enable_if_convertible_to_sexp = enable_if_t<std::is_convertible<T, SEXP>::value, R>;


### PR DESCRIPTION
Some compilers seem to be confused about `std::shared<T>` being constructible from SEXP. 
https://github.com/apache/arrow/pull/7819/checks?check_run_id=993750889#step:8:3524

```
array_from_vector.cpp: In function ‘std::shared_ptr<arrow::DataType> arrow::r::InferArrowTypeFromVector(SEXP) [with int VectorType = 4; SEXP = SEXPREC*]’:
3525
array_from_vector.cpp:1198:58: error: call of overloaded ‘as_cpp(SEXPREC*&)’ is ambiguous
3526
     return cpp11::as_cpp<std::shared_ptr<arrow::Array>>(x)->type();
3527
                                                          ^
3528
array_from_vector.cpp:1198:58: note: candidates are:
3529
In file included from /opt/R/3.6.3/lib/R/library/cpp11/include/cpp11.hpp:5:0,
3530
                 from ././arrow_cpp11.h:34,
3531
                 from ./arrow_types.h:22,
3532
                 from array_from_vector.cpp:20:
3533
/opt/R/3.6.3/lib/R/library/cpp11/include/cpp11/as.hpp:65:41: note: cpp11::enable_if_constructible_from_sexp<T, T> cpp11::as_cpp(SEXP) [with T = std::shared_ptr<arrow::Array>; cpp11::enable_if_constructible_from_sexp<T, T> = std::shared_ptr<arrow::Array>; SEXP = SEXPREC*]
3534
 enable_if_constructible_from_sexp<T, T> as_cpp(SEXP from) {
3535
                                         ^
3536
In file included from ./arrow_types.h:22:0,
3537
                 from array_from_vector.cpp:20:
3538
././arrow_cpp11.h:213:25: note: cpp11::enable_if_shared_ptr<T> cpp11::as_cpp(SEXP) [with T = std::shared_ptr<arrow::Array>; cpp11::enable_if_shared_ptr<T> = std::shared_ptr<arrow::Array>; SEXP = SEXPREC*]
3539
 enable_if_shared_ptr<T> as_cpp(SEXP from) {
3540
                         ^
3541
array_from_vector.cpp: In function ‘std::shared_ptr<arrow::Array> arrow::r::Array__from_vector(SEXP, const std::shared_ptr<arrow::DataType>&, bool)’:
```

ping @bkietz 
