### PR TITLE
Refactor conversion to use extensible trait structs

### DIFF
--- a/cpp11test/src/test-as.cpp
+++ b/cpp11test/src/test-as.cpp
@@ -8,6 +8,24 @@
 
 #include "Rcpp.h"
 
+struct Vec3 {
+  double x, y, z;
+};
+
+namespace cpp11 {
+template <>
+struct as_cpp_impl<Vec3> {
+  static Vec3 convert(SEXP from) {
+    if (Rf_isReal(from)) {
+      if (Rf_xlength(from) == 3) {
+        return {REAL_ELT(from, 0), REAL_ELT(from, 1), REAL_ELT(from, 2)};
+      }
+    }
+    stop("Expected three double values");
+  }
+};
+}  // namespace cpp11
+
 context("as_cpp-C++") {
   test_that("as_cpp<integer>(INTSEXP)") {
     SEXP r = PROTECT(Rf_allocVector(INTSXP, 1));
@@ -55,6 +73,18 @@ context("as_cpp-C++") {
 #endif
 
     UNPROTECT(1);
+  }
+
+  test_that("as_cpp<Vec3>(REALSXP)") {
+    SEXP r = PROTECT(Rf_allocVector(REALSXP, 3));
+    REAL(r)[0] = 1;
+    REAL(r)[1] = 2;
+    REAL(r)[2] = 4;
+
+    Vec3 v = cpp11::as_cpp<Vec3>(r);
+    expect_true(v.x == 1);
+    expect_true(v.y == 2);
+    expect_true(v.z == 4);
   }
 
   test_that("as_cpp<integer>(NA)") {
@@ -205,6 +235,20 @@ context("as_cpp-C++") {
     expect_true(x1[0] == 1);
     expect_true(x1[1] == 2);
     expect_true(x1[2] == 3);
+
+    UNPROTECT(1);
+  }
+
+  test_that("as_cpp<std::vector>(ALTREP_INTSXP)") {
+    SEXP r = PROTECT(R_compact_intrange(1, 5));
+
+    auto x1 = cpp11::as_cpp<std::vector<int>>(r);
+    expect_true(x1.size() == 5);
+    expect_true(x1[0] == 1);
+    expect_true(x1[1] == 2);
+    expect_true(x1[2] == 3);
+    expect_true(x1[3] == 4);
+    expect_true(x1[5] == 5);
 
     UNPROTECT(1);
   }

--- a/cpp11test/src/test-as.cpp
+++ b/cpp11test/src/test-as.cpp
@@ -239,19 +239,24 @@ context("as_cpp-C++") {
     UNPROTECT(1);
   }
 
+#if defined(__APPLE__) && defined(R_VERSION) && R_VERSION >= R_Version(3, 5, 0)
   test_that("as_cpp<std::vector>(ALTREP_INTSXP)") {
     SEXP r = PROTECT(R_compact_intrange(1, 5));
 
+    expect_true(ALTREP(r));
     auto x1 = cpp11::as_cpp<std::vector<int>>(r);
+    expect_true(ALTREP(r));
+
     expect_true(x1.size() == 5);
-    expect_true(x1[0] == 1);
-    expect_true(x1[1] == 2);
-    expect_true(x1[2] == 3);
-    expect_true(x1[3] == 4);
-    expect_true(x1[5] == 5);
+    int expected = 1;
+    for (int actual : x1) {
+      expect_true(actual == expected);
+      ++expected;
+    }
 
     UNPROTECT(1);
   }
+#endif
 
   test_that("as_cpp<std::vector<std::string>>()") {
     SEXP r = PROTECT(Rf_allocVector(STRSXP, 3));

--- a/inst/include/cpp11/as.hpp
+++ b/inst/include/cpp11/as.hpp
@@ -69,6 +69,11 @@ enable_if_t<is_convertible_to_sexp<T>::value, SEXP> as_sexp(const T& from) {
   return static_cast<SEXP>(from);
 }
 
+/// Override as_sexp so that as_sexp(r_string(...)) results in a single element vector
+/// instead of a CHRSXP
+class r_string;
+inline SEXP as_sexp(r_string from);
+
 template <typename T, typename = enable_if_t<!is_convertible_to_sexp<T>::value>>
 auto as_sexp(const T& from) -> decltype(as_sexp_impl<decay_t<T>>::convert(from)) {
   return as_sexp_impl<decay_t<T>>::convert(from);

--- a/inst/include/cpp11/as.hpp
+++ b/inst/include/cpp11/as.hpp
@@ -45,7 +45,7 @@ struct as_cpp_impl;
 template <typename T>
 enable_if_t<is_constructible_from_sexp<T>::value, T> as_cpp(SEXP from) {
   static_assert(std::is_same<decay_t<T>, T>::value, "");
-  return T{from};
+  return T(from);
 }
 
 template <typename T, typename = enable_if_t<!is_constructible_from_sexp<T>::value>>

--- a/inst/include/cpp11/as.hpp
+++ b/inst/include/cpp11/as.hpp
@@ -11,11 +11,11 @@
 
 namespace cpp11 {
 
-template <bool C, typename R = void>
-using enable_if_t = typename std::enable_if<C, R>::type;
-
 template <typename T>
 using decay_t = typename std::decay<T>::type;
+
+template <bool C, typename R = void>
+using enable_if_t = typename std::enable_if<C, R>::type;
 
 template <typename T>
 struct is_smart_ptr : std::false_type {};
@@ -29,11 +29,65 @@ struct is_smart_ptr<std::unique_ptr<T>> : std::true_type {};
 template <typename T>
 struct is_smart_ptr<std::weak_ptr<T>> : std::true_type {};
 
+template <typename T>
+using is_constructible_from_sexp = std::integral_constant<
+    bool, std::is_same<T, SEXP>::value ||
+              (!is_smart_ptr<T>::value &&  // workaround for gcc 4.8
+               std::is_class<T>::value && std::is_constructible<T, SEXP>::value)>;
+
+template <typename T>
+using is_convertible_to_sexp = std::is_convertible<T, SEXP>;
+
+template <typename T, typename Enable = void>
+struct as_cpp_impl;
+
+/// If T defines explicit construction from SEXP, that will override as_cpp_impl
+template <typename T>
+enable_if_t<is_constructible_from_sexp<T>::value, T> as_cpp(SEXP from) {
+  static_assert(std::is_same<decay_t<T>, T>::value, "");
+  return T{from};
+}
+
+template <typename T, typename = enable_if_t<!is_constructible_from_sexp<T>::value>>
+auto as_cpp(SEXP from) -> decltype(as_cpp_impl<T>::convert(from)) {
+  static_assert(std::is_same<decay_t<T>, T>::value, "");
+  return as_cpp_impl<T>::convert(from);
+}
+
+/// Temporary workaround for compatibility with cpp11 0.1.0
+template <typename T>
+enable_if_t<!std::is_same<decay_t<T>, T>::value, decay_t<T>> as_cpp(SEXP from) {
+  return as_cpp<decay_t<T>>(from);
+}
+
+template <typename T, typename Enable = void>
+struct as_sexp_impl;
+
+/// If T defines explicit construction from SEXP, that will override as_sexp_impl
+template <typename T>
+enable_if_t<is_convertible_to_sexp<T>::value, SEXP> as_sexp(const T& from) {
+  return static_cast<SEXP>(from);
+}
+
+template <typename T, typename = enable_if_t<!is_convertible_to_sexp<T>::value>>
+auto as_sexp(const T& from) -> decltype(as_sexp_impl<decay_t<T>>::convert(from)) {
+  return as_sexp_impl<decay_t<T>>::convert(from);
+}
+
+template <typename T>
+using is_integral = std::integral_constant<bool, std::is_integral<T>::value &&
+                                                     !std::is_same<T, bool>::value &&
+                                                     !std::is_same<T, char>::value>;
+
 template <typename T, typename R = void>
-using enable_if_constructible_from_sexp =
-    enable_if_t<!is_smart_ptr<T>::value &&  // workaround for gcc 4.8
-                    std::is_class<T>::value && std::is_constructible<T, SEXP>::value,
-                R>;
+using enable_if_integral = enable_if_t<is_integral<T>::value, R>;
+
+template <typename T, typename R = void>
+using enable_if_floating_point =
+    typename std::enable_if<std::is_floating_point<T>::value, R>::type;
+
+template <typename E, typename R = void>
+using enable_if_enum = enable_if_t<std::is_enum<E>::value, R>;
 
 template <typename T, typename R = void>
 using enable_if_is_sexp = enable_if_t<std::is_same<T, SEXP>::value, R>;
@@ -45,254 +99,215 @@ template <typename T, typename R = void>
 using disable_if_convertible_to_sexp =
     enable_if_t<!std::is_convertible<T, SEXP>::value, R>;
 
-template <typename T, typename R = void>
-using enable_if_integral =
-    enable_if_t<std::is_integral<T>::value && !std::is_same<T, bool>::value &&
-                    !std::is_same<T, char>::value,
-                R>;
-
-template <typename T, typename R = void>
-using enable_if_floating_point =
-    typename std::enable_if<std::is_floating_point<T>::value, R>::type;
-
-template <typename E, typename R = void>
-using enable_if_enum = enable_if_t<std::is_enum<E>::value, R>;
-
-template <typename T, typename R = void>
-using enable_if_bool = enable_if_t<std::is_same<T, bool>::value, R>;
-
-template <typename T, typename R = void>
-using enable_if_char = enable_if_t<std::is_same<T, char>::value, R>;
-
-template <typename T, typename R = void>
-using enable_if_std_string = enable_if_t<std::is_same<T, std::string>::value, R>;
-
-template <typename T, typename R = void>
-using enable_if_c_string = enable_if_t<std::is_same<T, const char*>::value, R>;
+namespace detail {
 
 // https://stackoverflow.com/a/1521682/2055486
-//
-inline bool is_convertable_without_loss_to_integer(double value) {
+static bool is_convertible_without_loss_to_integer(double value) {
   double int_part;
   return std::modf(value, &int_part) == 0.0;
 }
 
-template <typename T>
-enable_if_constructible_from_sexp<T, T> as_cpp(SEXP from) {
-  return T(from);
-}
+template <typename E, typename Underlying = typename std::underlying_type<E>::type>
+using enum_to_int_type =
+    typename std::conditional<std::is_same<char, Underlying>::value,
+                              int,  // `char` triggers undesired string conversions
+                              Underlying>::type;
+
+}  // namespace detail
 
 template <typename T>
-enable_if_is_sexp<T, T> as_cpp(SEXP from) {
-  return from;
-}
+struct as_cpp_impl<T, enable_if_integral<T>> {
+  static T convert(SEXP from) {
+    if (Rf_isInteger(from)) {
+      if (Rf_xlength(from) == 1) {
+        return INTEGER_ELT(from, 0);
+      }
+    } else if (Rf_isReal(from)) {
+      if (Rf_xlength(from) == 1) {
+        if (ISNA(REAL_ELT(from, 0))) {
+          return NA_INTEGER;
+        }
+        double value = REAL_ELT(from, 0);
+        if (detail::is_convertible_without_loss_to_integer(value)) {
+          return value;
+        }
+      }
+    } else if (Rf_isLogical(from)) {
+      if (Rf_xlength(from) == 1) {
+        if (LOGICAL_ELT(from, 0) == NA_LOGICAL) {
+          return NA_INTEGER;
+        }
+      }
+    }
 
-template <typename T>
-enable_if_integral<T, T> as_cpp(SEXP from) {
-  if (Rf_isInteger(from)) {
-    if (Rf_xlength(from) == 1) {
-      return INTEGER_ELT(from, 0);
-    }
-  } else if (Rf_isReal(from)) {
-    if (Rf_xlength(from) == 1) {
-      if (ISNA(REAL_ELT(from, 0))) {
-        return NA_INTEGER;
-      }
-      double value = REAL_ELT(from, 0);
-      if (is_convertable_without_loss_to_integer(value)) {
-        return value;
-      }
-    }
-  } else if (Rf_isLogical(from)) {
-    if (Rf_xlength(from) == 1) {
-      if (LOGICAL_ELT(from, 0) == NA_LOGICAL) {
-        return NA_INTEGER;
-      }
-    }
+    stop("Expected single integer value");
   }
+};
 
-  stop("Expected single integer value");
-}
+template <typename T>
+struct as_sexp_impl<T, enable_if_integral<T>> {
+  static SEXP convert(T from) { return safe[Rf_ScalarInteger](from); }
+};
 
 template <typename E>
-enable_if_enum<E, E> as_cpp(SEXP from) {
-  if (Rf_isInteger(from)) {
-    using underlying_type = typename std::underlying_type<E>::type;
-    using int_type = typename std::conditional<std::is_same<char, underlying_type>::value,
-                                               int,  // as_cpp<char> would trigger
-                                                     // undesired string conversions
-                                               underlying_type>::type;
-    return static_cast<E>(as_cpp<int_type>(from));
-  }
-
-  stop("Expected single integer value");
-}
-
-template <typename T>
-enable_if_bool<T, T> as_cpp(SEXP from) {
-  if (Rf_isLogical(from)) {
-    if (Rf_xlength(from) == 1) {
-      return LOGICAL_ELT(from, 0) == 1;
+struct as_cpp_impl<E, enable_if_enum<E>> {
+  static E convert(SEXP from) {
+    if (Rf_isInteger(from)) {
+      return static_cast<E>(as_cpp<detail::enum_to_int_type<E>>(from));
     }
-  }
 
-  stop("Expected single logical value");
-}
-
-template <typename T>
-enable_if_floating_point<T, T> as_cpp(SEXP from) {
-  if (Rf_isReal(from)) {
-    if (Rf_xlength(from) == 1) {
-      return REAL_ELT(from, 0);
-    }
+    stop("Expected single integer value");
   }
-  // All 32 bit integers can be coerced to doubles, so we just convert them.
-  if (Rf_isInteger(from)) {
-    if (Rf_xlength(from) == 1) {
-      if (INTEGER_ELT(from, 0) == NA_INTEGER) {
-        return NA_REAL;
-      }
-      return INTEGER_ELT(from, 0);
-    }
-  }
+};
 
-  // Also allow NA values
-  if (Rf_isLogical(from)) {
-    if (Rf_xlength(from) == 1) {
-      if (LOGICAL_ELT(from, 0) == NA_LOGICAL) {
-        return NA_REAL;
+template <typename E>
+struct as_sexp_impl<E, enable_if_enum<E>> {
+  static SEXP convert(E from) {
+    return as_sexp(static_cast<detail::enum_to_int_type<E>>(from));
+  }
+};
+
+template <>
+struct as_cpp_impl<bool> {
+  static bool convert(SEXP from) {
+    if (Rf_isLogical(from)) {
+      if (Rf_xlength(from) == 1) {
+        return LOGICAL_ELT(from, 0) == 1;
       }
     }
-  }
 
-  stop("Expected single double value");
-}
+    stop("Expected single logical value");
+  }
+};
+
+template <>
+struct as_sexp_impl<bool> {
+  static SEXP convert(bool from) { return safe[Rf_ScalarLogical](from); }
+};
 
 template <typename T>
-enable_if_char<T, T> as_cpp(SEXP from) {
-  if (Rf_isString(from)) {
-    if (Rf_xlength(from) == 1) {
-      return unwind_protect([&] { return Rf_translateCharUTF8(STRING_ELT(from, 0))[0]; });
+struct as_cpp_impl<T, enable_if_floating_point<T>> {
+  static T convert(SEXP from) {
+    if (Rf_isReal(from)) {
+      if (Rf_xlength(from) == 1) {
+        return REAL_ELT(from, 0);
+      }
     }
-  }
-
-  stop("Expected string vector of length 1");
-}
-
-template <typename T>
-enable_if_c_string<T, T> as_cpp(SEXP from) {
-  if (Rf_isString(from)) {
-    if (Rf_xlength(from) == 1) {
-      // TODO: use vmaxget / vmaxset here?
-      return {unwind_protect([&] { return Rf_translateCharUTF8(STRING_ELT(from, 0)); })};
+    // All 32 bit integers can be coerced to doubles, so we just convert them.
+    if (Rf_isInteger(from)) {
+      if (Rf_xlength(from) == 1) {
+        if (INTEGER_ELT(from, 0) == NA_INTEGER) {
+          return NA_REAL;
+        }
+        return INTEGER_ELT(from, 0);
+      }
     }
+
+    // Also allow NA values
+    if (Rf_isLogical(from)) {
+      if (Rf_xlength(from) == 1) {
+        if (LOGICAL_ELT(from, 0) == NA_LOGICAL) {
+          return NA_REAL;
+        }
+      }
+    }
+
+    stop("Expected single double value");
   }
-
-  stop("Expected string vector of length 1");
-}
+};
 
 template <typename T>
-enable_if_std_string<T, T> as_cpp(SEXP from) {
-  return {as_cpp<const char*>(from)};
-}
+struct as_sexp_impl<T, enable_if_floating_point<T>> {
+  static SEXP convert(T from) { return safe[Rf_ScalarReal](from); }
+};
 
-/// Temporary workaround for compatibility with cpp11 0.1.0
-template <typename T>
-enable_if_t<!std::is_same<decay_t<T>, T>::value, decay_t<T>> as_cpp(SEXP from) {
-  return as_cpp<decay_t<T>>(from);
-}
+template <>
+struct as_cpp_impl<const char*> {
+  static const char* convert(SEXP from) {
+    if (Rf_isString(from)) {
+      if (Rf_xlength(from) == 1) {
+        // NB: vmaxget/vmaxset here would cause translated strings to be freed before
+        // return. Without this explicit management, the return value of as_cpp<const
+        // char*>(str) will freed at the end of the call to .C, .Call, or .External
+        return unwind_protect([&] { return Rf_translateCharUTF8(STRING_ELT(from, 0)); });
+      }
+    }
 
-template <typename T>
-enable_if_integral<T, SEXP> as_sexp(T from) {
-  return safe[Rf_ScalarInteger](from);
-}
-
-template <typename T>
-enable_if_floating_point<T, SEXP> as_sexp(T from) {
-  return safe[Rf_ScalarReal](from);
-}
-
-template <typename T>
-enable_if_bool<T, SEXP> as_sexp(T from) {
-  return safe[Rf_ScalarLogical](from);
-}
-
-template <typename T>
-enable_if_c_string<T, SEXP> as_sexp(T from) {
-  return unwind_protect([&] { return Rf_ScalarString(Rf_mkCharCE(from, CE_UTF8)); });
-}
-
-template <typename T>
-enable_if_std_string<T, SEXP> as_sexp(const T& from) {
-  return as_sexp(from.c_str());
-}
-
-template <typename Container, typename T = typename Container::value_type,
-          typename = disable_if_convertible_to_sexp<Container>>
-enable_if_integral<T, SEXP> as_sexp(const Container& from) {
-  R_xlen_t size = from.size();
-  SEXP data = safe[Rf_allocVector](INTSXP, size);
-
-  auto it = from.begin();
-  int* data_p = INTEGER(data);
-  for (R_xlen_t i = 0; i < size; ++i, ++it) {
-    data_p[i] = *it;
+    stop("Expected string vector of length 1");
   }
-  return data;
-}
+};
 
-inline SEXP as_sexp(std::initializer_list<int> from) {
-  return as_sexp<std::initializer_list<int>>(from);
-}
-
-template <typename Container, typename T = typename Container::value_type,
-          typename = disable_if_convertible_to_sexp<Container>>
-enable_if_floating_point<T, SEXP> as_sexp(const Container& from) {
-  R_xlen_t size = from.size();
-  SEXP data = safe[Rf_allocVector](REALSXP, size);
-
-  auto it = from.begin();
-  double* data_p = REAL(data);
-  for (R_xlen_t i = 0; i < size; ++i, ++it) {
-    data_p[i] = *it;
+template <>
+struct as_sexp_impl<const char*> {
+  static SEXP convert(const char* from) {
+    return unwind_protect([&] { return Rf_ScalarString(Rf_mkCharCE(from, CE_UTF8)); });
   }
-  return data;
-}
+};
 
-inline SEXP as_sexp(std::initializer_list<double> from) {
-  return as_sexp<std::initializer_list<double>>(from);
-}
+template <>
+struct as_sexp_impl<char*> {
+  static SEXP convert(const char* from) { return as_sexp(from); }
+};
 
-template <typename Container, typename T = typename Container::value_type,
-          typename = disable_if_convertible_to_sexp<Container>>
-enable_if_bool<T, SEXP> as_sexp(const Container& from) {
-  R_xlen_t size = from.size();
-  SEXP data = safe[Rf_allocVector](LGLSXP, size);
+template <>
+struct as_cpp_impl<std::string> {
+  static std::string convert(SEXP from) { return as_cpp<const char*>(from); }
+};
 
-  auto it = from.begin();
-  int* data_p = LOGICAL(data);
-  for (R_xlen_t i = 0; i < size; ++i, ++it) {
-    data_p[i] = *it;
-  }
-  return data;
-}
+template <>
+struct as_sexp_impl<std::string> {
+  static SEXP convert(const std::string& from) { return as_sexp(from.c_str()); }
+};
 
-inline SEXP as_sexp(std::initializer_list<bool> from) {
-  return as_sexp<std::initializer_list<bool>>(from);
-}
+template <>
+struct as_cpp_impl<char> {
+  static char convert(SEXP from) { return as_cpp<const char*>(from)[0]; }
+};
+
+template <>
+struct as_sexp_impl<char> {
+  static SEXP convert(char from) { return as_sexp(std::string({from})); }
+};
 
 namespace detail {
-template <typename Container, typename AsCstring>
-SEXP as_sexp_strings(const Container& from, AsCstring&& c_str) {
+
+template <SEXPTYPE t>
+using sexptype_constant = std::integral_constant<SEXPTYPE, t>;
+
+inline int* get_raws(SEXP vec, sexptype_constant<LGLSXP>) { return LOGICAL(vec); }
+inline int* get_raws(SEXP vec, sexptype_constant<INTSXP>) { return INTEGER(vec); }
+inline double* get_raws(SEXP vec, sexptype_constant<REALSXP>) { return REAL(vec); }
+
+template <typename Container, SEXPTYPE t>
+SEXP as_sexp_raws(const Container& from, sexptype_constant<t> sexptype) {
   R_xlen_t size = from.size();
+  SEXP data = PROTECT(safe[Rf_allocVector](sexptype, size));
 
-  SEXP data;
+  auto raw_data = get_raws(data, sexptype);
+  for (auto el : from) {
+    *raw_data++ = el;
+  }
+
+  UNPROTECT(1);
+  return data;
+}
+
+template <typename Container, SEXPTYPE t>
+Container as_cpp_raws(SEXP from, sexptype_constant<t> sexptype) {
+  // FIXME altrep is broken
+  auto raw_data = get_raws(from, sexptype);
+  return Container{raw_data, raw_data + Rf_xlength(from)};
+}
+
+template <typename Container, typename ToCstring>
+SEXP as_sexp_strings(const Container& from, const ToCstring& to_c_str) {
+  R_xlen_t size = from.size();
+  SEXP data = PROTECT(safe[Rf_allocVector](STRSXP, size));
+
   try {
-    data = PROTECT(safe[Rf_allocVector](STRSXP, size));
-
-    auto it = from.begin();
-    for (R_xlen_t i = 0; i < size; ++i, ++it) {
-      SET_STRING_ELT(data, i, safe[Rf_mkCharCE](c_str(*it), CE_UTF8));
+    R_xlen_t i = 0;
+    for (const auto& s : from) {
+      SET_STRING_ELT(data, i++, safe[Rf_mkCharCE](to_c_str(s), CE_UTF8));
     }
   } catch (const unwind_exception& e) {
     UNPROTECT(1);
@@ -302,34 +317,129 @@ SEXP as_sexp_strings(const Container& from, AsCstring&& c_str) {
   UNPROTECT(1);
   return data;
 }
-}  // namespace detail
 
-class r_string;
+template <typename Container>
+Container as_cpp_strings(SEXP from) {
+  struct iterator {
+    using difference_type = int;
+    using value_type = const char*;
+    using reference = value_type&;
+    using pointer = value_type*;
+    using iterator_category = std::forward_iterator_tag;
 
-template <typename T, typename R = void>
-using disable_if_r_string = enable_if_t<!std::is_same<T, cpp11::r_string>::value, R>;
+    const char* operator*() const {
+      return Rf_translateCharUTF8(STRING_ELT(data_, index_));
+    }
 
-template <typename Container, typename T = typename Container::value_type,
-          typename = disable_if_r_string<T>>
-enable_if_t<std::is_convertible<T, std::string>::value &&
-                !std::is_convertible<T, const char*>::value,
-            SEXP>
-as_sexp(const Container& from) {
-  return detail::as_sexp_strings(from, [](const std::string& s) { return s.c_str(); });
+    iterator& operator++() {
+      ++index_;
+      return *this;
+    }
+
+    bool operator!=(const iterator& other) const { return index_ != other.index_; }
+
+    SEXP data_;
+    R_xlen_t index_;
+  };
+
+  iterator begin{from, 0};
+  iterator end{from, Rf_xlength(from)};
+  return Container(begin, end);
 }
 
-template <typename Container, typename T = typename Container::value_type>
-enable_if_c_string<T, SEXP> as_sexp(const Container& from) {
-  return detail::as_sexp_strings(from, [](const char* s) { return s; });
+}  // namespace detail
+
+template <typename Container>
+struct as_cpp_impl<Container,
+                   enable_if_t<is_integral<typename Container::value_type>::value>> {
+  static Container convert(SEXP from) {
+    return detail::as_cpp_raws<Container>(from, detail::sexptype_constant<INTSXP>{});
+  }
+};
+
+template <typename Container>
+struct as_cpp_impl<
+    Container,
+    enable_if_t<std::is_floating_point<typename Container::value_type>::value>> {
+  static Container convert(SEXP from) {
+    return detail::as_cpp_raws<Container>(from, detail::sexptype_constant<REALSXP>{});
+  }
+};
+
+template <typename Container>
+struct as_cpp_impl<
+    Container, enable_if_t<std::is_same<typename Container::value_type, bool>::value>> {
+  static Container convert(SEXP from) {
+    return detail::as_cpp_raws<Container>(from, detail::sexptype_constant<LGLSXP>{});
+  }
+};
+
+template <typename Container>
+struct as_cpp_impl<Container, enable_if_t<std::is_constructible<
+                                  typename Container::value_type, const char*>::value>> {
+  static Container convert(SEXP from) { return detail::as_cpp_strings<Container>(from); }
+};
+
+template <typename Container>
+struct as_sexp_impl<Container,
+                    enable_if_t<is_integral<typename Container::value_type>::value>> {
+  static SEXP convert(const Container& from) {
+    return detail::as_sexp_raws<Container>(from, detail::sexptype_constant<INTSXP>{});
+  }
+};
+
+template <typename Container>
+struct as_sexp_impl<
+    Container,
+    enable_if_t<std::is_floating_point<typename Container::value_type>::value>> {
+  static SEXP convert(const Container& from) {
+    return detail::as_sexp_raws<Container>(from, detail::sexptype_constant<REALSXP>{});
+  }
+};
+
+template <typename Container>
+struct as_sexp_impl<
+    Container, enable_if_t<std::is_same<typename Container::value_type, bool>::value>> {
+  static SEXP convert(const Container& from) {
+    return detail::as_sexp_raws<Container>(from, detail::sexptype_constant<LGLSXP>{});
+  }
+};
+
+template <typename Container>
+struct as_sexp_impl<
+    Container,
+    enable_if_t<std::is_same<typename Container::value_type, std::string>::value>> {
+  static SEXP convert(const Container& from) {
+    return detail::as_sexp_strings<Container>(
+        from, [](const std::string& s) { return s.c_str(); });
+  }
+};
+
+template <typename Container>
+struct as_sexp_impl<Container, enable_if_t<std::is_convertible<
+                                   typename Container::value_type, const char*>::value>> {
+  static SEXP convert(const Container& from) {
+    return detail::as_sexp_strings<Container>(
+        from, [](const typename Container::value_type& s) {
+          return static_cast<const char*>(s);
+        });
+  }
+};
+
+inline SEXP as_sexp(std::initializer_list<int> from) {
+  return as_sexp<std::initializer_list<int>>(from);
+}
+
+inline SEXP as_sexp(std::initializer_list<double> from) {
+  return as_sexp<std::initializer_list<double>>(from);
+}
+
+inline SEXP as_sexp(std::initializer_list<bool> from) {
+  return as_sexp<std::initializer_list<bool>>(from);
 }
 
 inline SEXP as_sexp(std::initializer_list<const char*> from) {
   return as_sexp<std::initializer_list<const char*>>(from);
-}
-
-template <typename T, typename = disable_if_r_string<T>>
-enable_if_convertible_to_sexp<T, SEXP> as_sexp(const T& from) {
-  return from;
 }
 
 }  // namespace cpp11

--- a/inst/include/cpp11/r_string.hpp
+++ b/inst/include/cpp11/r_string.hpp
@@ -68,12 +68,10 @@ inline SEXP as_sexp(std::initializer_list<r_string> il) {
 
 inline bool is_na(const r_string& x) { return x == NA_STRING; }
 
-template <typename T, typename R = void>
-using enable_if_r_string = enable_if_t<std::is_same<T, cpp11::r_string>::value, R>;
-
-template <typename T>
-enable_if_r_string<T, SEXP> as_sexp(T from) {
+// override as_sexp so that r_strings convert to single element vectors
+inline SEXP as_sexp(r_string from) {
   r_string str(from);
+
   sexp res;
   unwind_protect([&] {
     res = Rf_allocVector(STRSXP, 1);

--- a/inst/include/cpp11/r_string.hpp
+++ b/inst/include/cpp11/r_string.hpp
@@ -68,7 +68,6 @@ inline SEXP as_sexp(std::initializer_list<r_string> il) {
 
 inline bool is_na(const r_string& x) { return x == NA_STRING; }
 
-// override as_sexp so that r_strings convert to single element vectors
 inline SEXP as_sexp(r_string from) {
   r_string str(from);
 

--- a/inst/include/cpp11/r_vector.hpp
+++ b/inst/include/cpp11/r_vector.hpp
@@ -922,42 +922,6 @@ inline void r_vector<T>::proxy::operator++() {
 
 }  // namespace writable
 
-// TODO: is there a better condition we could use, e.g. assert something true
-// rather than three things false?
-template <typename C, typename T>
-using is_container_but_not_sexp_or_string = typename std::enable_if<
-    !std::is_constructible<C, SEXP>::value &&
-        !std::is_same<typename std::decay<C>::type, std::string>::value &&
-        !std::is_same<typename std::decay<T>::type, std::string>::value,
-    typename std::decay<C>::type>::type;
-
-template <typename C, typename T = typename std::decay<C>::type::value_type>
-// typename T = typename C::value_type>
-is_container_but_not_sexp_or_string<C, T> as_cpp(SEXP from) {
-  auto obj = cpp11::r_vector<T>(from);
-  return {obj.begin(), obj.end()};
-}
-
-// TODO: could we make this generalize outside of std::string?
-template <typename C, typename T = C>
-using is_vector_of_strings = typename std::enable_if<
-    std::is_same<typename std::decay<T>::type, std::string>::value,
-    typename std::decay<C>::type>::type;
-
-template <typename C, typename T = typename std::decay<C>::type::value_type>
-// typename T = typename C::value_type>
-is_vector_of_strings<C, T> as_cpp(SEXP from) {
-  auto obj = cpp11::r_vector<cpp11::r_string>(from);
-  typename std::decay<C>::type res;
-  auto it = obj.begin();
-  while (it != obj.end()) {
-    r_string s = *it;
-    res.emplace_back(static_cast<std::string>(s));
-    ++it;
-  }
-  return res;
-}
-
 template <typename T>
 bool operator==(const r_vector<T>& lhs, const r_vector<T>& rhs) {
   if (lhs.size() != rhs.size()) {

--- a/vignettes/internals.Rmd
+++ b/vignettes/internals.Rmd
@@ -100,7 +100,28 @@ This is definitely the most complex part of the cpp11 code, with extensive use o
 In particular the [substitution failure is not an error (SFINAE)](https://en.wikipedia.org/wiki/Substitution_failure_is_not_an_error) technique is used to control overloading of the functions.
 If we could use C++20 a lot of this code would be made simpler with [Concepts](https://en.cppreference.com/w/cpp/language/constraints), but alas.
 
-The most common C++ types are included in the test suite and should work without issues, as more exotic types are used in real projects additional issues may arise.
+A range of common C++ types are included in the test suite and should work without issues.
+To add custom coercion behavior, define `operator SEXP()` and a constructor which takes an SEXP.
+These will be used by `as_sexp()` and `as_cpp<>()` respectively, if available.
+If constructors or conversion operators cannot be defined, coercion behavior can be customized by specializing the trait structs `as_sexp_impl` and `as_cpp_impl` respectively.
+(cpp11's own coercion logic for STL containers is defined by specializing these traits since we can't add members to `std::vector`.)
+For example, to define coercion from SEXP to `struct Vec3 { double x,y,z; };`:
+
+```c++
+namespace cpp11 {
+template <>
+struct as_cpp_impl<Vec3> {
+  static Vec3 convert(SEXP from) {
+    if (Rf_isReal(from) && Rf_xlength(from) == 3) {
+      return Vec3{REAL_ELT(from, 0), REAL_ELT(from, 1), REAL_ELT(from, 2)};
+    }
+    stop("Expected three double values");
+  }
+};
+}
+```
+
+Note that specializing `as_sexp_impl` will never override an explicit conversion operator to SEXP, nor will specializing `as_cpp_impl` override a constructor from SEXP.
 
 Some useful links on SFINAE
 


### PR DESCRIPTION
Still a little half baked:
- [x] Move all conversion logic to an extensible trait structs
- [x] Generalize container conversion
- [ ] Fix conversion from altrep vectors
- [x] Add doc indicating how and when to specialize the trait structs