### PR TITLE
Store the protect list as an XPtr rather than in an environment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # cpp11 (development version)
 
 * `r_vector::const_iterator::operator*` is now a const method (#113, @bkietz, @xhochy)
+* The preserve list is now stored in an XPtr, rather than an environment, to avoid issues when serializing the preserve environment, which happens implicitly when RStudio or RStudio Cloud saves all options when resuming a session (#116)
 
 # cpp11 0.2.2
 


### PR DESCRIPTION
Using an environment as previously done generates a stack overflow when
serialized.

The data part of XPtrs is not serialized, so avoids this issue, while
also avoiding the copying issues that prompted use of an environment.