### PR TITLE
Use a local textConnection object

### DIFF
--- a/R/register.R
+++ b/R/register.R
@@ -239,7 +239,7 @@ wrap_call <- function(name, return_type, args) {
 }
 
 get_call_entries <- function(path) {
-  con <- textConnection("res", open = "w")
+  con <- textConnection("res", local = TRUE, open = "w")
 
   try(
     tools::package_native_routine_registration_skeleton(path,


### PR DESCRIPTION
Without this flag, an object 'res' is created in the user's global environment

Reprex to see the issue:

```r
local({
  path <- tempfile()
  dir.create(path)
  dir.create(file.path(path, "src"))
  dir.create(file.path(path, "R"))
  writeLines(c("Package: pkg", "Version: 0.1.0", "LinkingTo: cpp11"),
             file.path(path, "DESCRIPTION"))
  writeLines("useDynLib(pkg, .registration = TRUE)",
             file.path(path, "NAMESPACE"))
  writeLines(c("[[cpp11::register]]",
               "double add(double a, double b) {",
               "  return a + b;",
               "}"),
             file.path(path, "src", "code.cpp"))
  cpp11::cpp_register(path)
})
ls(.GlobalEnv)
#> [1] "res"
head(res)
#> [1] "#include <R.h>"                  "#include <Rinternals.h>"        
#> [3] "#include <stdlib.h> // for NULL" "#include <R_ext/Rdynload.h>"    
#> [5] ""                                "/* FIXME: "                     
```