### PR TITLE
describe addition of useDynLib in cpp11 vignette

### DIFF
--- a/vignettes/cpp11.Rmd
+++ b/vignettes/cpp11.Rmd
@@ -1099,11 +1099,19 @@ There are several benefits of moving code from a stand-alone C++ source file to 
 
 1. Packages provide additional infrastructure for testing, documentation, and consistency.
 
-To add `cpp11` to an existing package, you put your C++ files in the `src/` directory and add the following to your `DESCRIPTION` file.
+To add `cpp11` to an existing package, you put your C++ files in the `src/` directory, add the following to your `DESCRIPTION` file:
 
     ```
     LinkingTo: cpp11
     ```
+
+and the following to your `R/<mypakage>` file:
+
+    ```
+    useDynLib <mypackage>, .registration = TRUE
+    ```
+
+You'll then need to run [`devtools::document()`](https://devtools.r-lib.org/reference/document.html) to update your `NAMESPACE` file to include the `useDynLib` statement.
 
 The easiest way to set this up automatically is to call `usethis::use_cpp11()`.
 


### PR DESCRIPTION
Without this, explicitly following the current instructions of just adding `LinkingTo` fails, likely leaving many to attempt `usethis::use_cpp11()`, which also fails because of [this :bug:](https://github.com/r-lib/usethis/pull/1329). Once `use_cpp11()` works after *only* adding `LinkingTo`, and not `useDynLib`, and once the vignette has been updated with this PR, then the entire procedure should be sufficiently robust that any potential combination of these approaches should give the desired result of enabling use of `cpp11`. Thanks as always @jimhester  for the awesome work. Hope that helps!