### PR TITLE
Fix handling of whitespace in Makevars filename

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cpp11
 Title: A C++11 Interface for R's C Interface
-Version: 0.2.7
+Version: 0.2.7.9000
 Authors@R: 
     c(person(given = "Jim",
              family = "Hester",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# cpp11 (development version)
+
+* Fix handling of spaces in Makevars include filenames (@klmr, #160)
+
 # cpp11 0.2.7
 
 * Fix a transient memory leak for functions that return values from `cpp11::unwind_protect()` and `cpp11::safe` (#154)

--- a/R/source.R
+++ b/R/source.R
@@ -153,12 +153,13 @@ generate_include_paths <- function(packages) {
     if (is_windows()) {
       path <- shQuote(utils::shortPathName(path))
     }
-    out[[i]] <- paste0("-I", shQuote(path))
+    out[[i]] <- paste0("-I", path)
   }
   out
 }
 
 generate_makevars <- function(includes, cxx_std) {
+  includes <- gsub(" ", "\\\\ ", includes)
   c(sprintf("CXX_STD=%s", cxx_std), sprintf("PKG_CPPFLAGS=%s", paste0(includes, collapse = " ")))
 }
 

--- a/R/source.R
+++ b/R/source.R
@@ -153,7 +153,7 @@ generate_include_paths <- function(packages) {
     if (is_windows()) {
       path <- shQuote(utils::shortPathName(path))
     }
-    out[[i]] <- paste0("-I'", path, "'")
+    out[[i]] <- paste0("-I", shQuote(path))
   }
   out
 }

--- a/R/source.R
+++ b/R/source.R
@@ -153,13 +153,12 @@ generate_include_paths <- function(packages) {
     if (is_windows()) {
       path <- shQuote(utils::shortPathName(path))
     }
-    out[[i]] <- paste0("-I", path)
+    out[[i]] <- paste0("-I'", path, "'")
   }
   out
 }
 
 generate_makevars <- function(includes, cxx_std) {
-  includes <- gsub(" ", "\\ ", includes)
   c(sprintf("CXX_STD=%s", cxx_std), sprintf("PKG_CPPFLAGS=%s", paste0(includes, collapse = " ")))
 }
 

--- a/R/source.R
+++ b/R/source.R
@@ -151,15 +151,14 @@ generate_include_paths <- function(packages) {
   for (i in seq_along(packages)) {
     path <- system.file(package = packages[[i]], "include")
     if (is_windows()) {
-      path <- shQuote(utils::shortPathName(path))
+      path <- utils::shortPathName(path)
     }
-    out[[i]] <- paste0("-I", path)
+    out[[i]] <- paste0("-I", shQuote(path))
   }
   out
 }
 
 generate_makevars <- function(includes, cxx_std) {
-  includes <- gsub(" ", "\\\\ ", includes)
   c(sprintf("CXX_STD=%s", cxx_std), sprintf("PKG_CPPFLAGS=%s", paste0(includes, collapse = " ")))
 }
 

--- a/R/source.R
+++ b/R/source.R
@@ -159,6 +159,7 @@ generate_include_paths <- function(packages) {
 }
 
 generate_makevars <- function(includes, cxx_std) {
+  includes <- gsub(" ", "\\ ", includes)
   c(sprintf("CXX_STD=%s", cxx_std), sprintf("PKG_CPPFLAGS=%s", paste0(includes, collapse = " ")))
 }
 

--- a/tests/testthat/test-source.R
+++ b/tests/testthat/test-source.R
@@ -91,3 +91,13 @@ expect_equal(
   "foo_3.cpp"
   )
 })
+
+test_that("generate_include_paths handles paths with spaces", {
+  if (is_windows()) {
+    mockery::stub(generate_include_paths, "system.file", "C:\\a path with spaces\\cpp11")
+    expect_equal(generate_include_paths("cpp11"), "-I\"C:\\a path with spaces\\cpp11\"")
+  } else {
+    mockery::stub(generate_include_paths, "system.file", "/a path with spaces/cpp11")
+    expect_equal(generate_include_paths("cpp11"), "-I'/a path with spaces/cpp11'")
+  }
+})


### PR DESCRIPTION
This PR adds escaping of spaces in path names that are written to the `Makevars` file used by ‘cpp11’ for compilation.

I came across this issue because I’m keeping my R package library on macOS in the standard config location, which is `~/Library/Application Support` (note the space). Since ‘cpp11’ adds its own installation directory to the include path, this consequently causes an error when invoking e.g. `cpp_source()`, which looks as follows:

>     clang: error: no such file or directory: 'Support/R/4.0/library/cpp11/include'
>     make: *** [/private/var/folders/dr/rp46tjqs5qzfj_ghjpxqrttr0000gn/T/RtmpMtBJTo/file13e521450b665/src/code_13e523ef6ab4e.o] Error 1
>     Error: Compilation failed.