### PR TITLE
Bug - cpp11 source file names

### DIFF
--- a/R/source.R
+++ b/R/source.R
@@ -91,11 +91,14 @@ cpp_source <- function(file, code = NULL, env = parent.frame(), clean = TRUE, qu
     package <- tools::file_path_sans_ext(name)
   }
   else {
+    # name and package might be different if cpp_source was called multiple times
     name <- basename(file)
     package <- tools::file_path_sans_ext(generate_cpp_name(file))
   }
 
+  # file not points to another location
   file.copy(file, file.path(dir, "src", name))
+  #change variable name to reflect this
   file <- file.path(dir, "src", name)
 
 
@@ -131,13 +134,8 @@ cpp_source <- function(file, code = NULL, env = parent.frame(), clean = TRUE, qu
     stop("Compilation failed.", call. = FALSE)
   }
 
-  if (base_cpp) {
-    shared_lib <- file.path(dir, "src", paste0(tools::file_path_sans_ext(basename(file)), .Platform$dynlib.ext))
-  }
-  else {
-    shared_lib <- file.path(dir, "src", paste0(package, .Platform$dynlib.ext))
-  }
 
+  shared_lib <- file.path(dir, "src", paste0(tools::file_path_sans_ext(basename(file)), .Platform$dynlib.ext))
   r_path <- file.path(dir, "R", "cpp11.R")
   brio::write_lines(r_functions, r_path)
   source(r_path, local = env)

--- a/R/source.R
+++ b/R/source.R
@@ -84,11 +84,20 @@ cpp_source <- function(file, code = NULL, env = parent.frame(), clean = TRUE, qu
     stop("`file` must have a `.cpp` or `.cc` extension")
   }
 
-  name <- basename(file)
-  package <- tools::file_path_sans_ext(generate_cpp_name(file))
+
+
+  if (basename(file) %in% "cpp11.cpp") {
+    name <- generate_cpp_name(file)
+    package <- tools::file_path_sans_ext(name)
+  }
+  else {
+    name <- basename(file)
+    package <- tools::file_path_sans_ext(generate_cpp_name(file))
+  }
 
   file.copy(file, file.path(dir, "src", name))
   file <- file.path(dir, "src", name)
+
 
   suppressWarnings(
     all_decorations <- decor::cpp_decorations(dir, is_attribute = TRUE)

--- a/R/source.R
+++ b/R/source.R
@@ -156,6 +156,20 @@ generate_cpp_name <- function(name, loaded_dlls = c("cpp11", names(getLoadedDLLs
   sprintf("%s.%s", new_name, ext)
 }
 
+generate_cpp_name2 <- function(name, loaded_dlls = c("cpp11", names(getLoadedDLLs()))) {
+  ext <- tools::file_ext(name)
+  root <- tools::file_path_sans_ext(basename(name))
+  count <- 2
+  new_name <- root
+  while(new_name %in% loaded_dlls) {
+    new_name <- sprintf("%s_%i", root, count)
+    count <- count + 1
+  }
+  sprintf("%s.%s", new_name, ext)
+}
+
+
+
 generate_include_paths <- function(packages) {
   out <- character(length(packages))
   for (i in seq_along(packages)) {

--- a/tests/testthat/test-source.R
+++ b/tests/testthat/test-source.R
@@ -101,3 +101,7 @@ test_that("generate_include_paths handles paths with spaces", {
     expect_equal(generate_include_paths("cpp11"), "-I'/a path with spaces/cpp11'")
   }
 })
+
+test_that("", {
+
+})

--- a/tests/testthat/test-source.R
+++ b/tests/testthat/test-source.R
@@ -102,6 +102,3 @@ test_that("generate_include_paths handles paths with spaces", {
   }
 })
 
-test_that("", {
-
-})


### PR DESCRIPTION
This should fix the R CMD check errors and still prevent source file name changes. 