### PR TITLE
adding empty to vector classes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # cpp11 (development version)
 
-*Added `named()` and `empty()` methods to r_vector classes, returning true if named/empty (@sbearrows, #182, #186) 
+* Added `x.empty()` method to check if a vector is empty (@sbearrows, #182)
 * New `cpp11::na()` function to return the NA sentinals for R objects(@sbearrows, #179)
 * Incorrectly formatted cpp11 decorators now output a more informative error message (@sbearrows, #127)
 * Generated registration code now uses C collation to avoid spurious diffs from `tools::package_native_routine_registration_skeleton()` (@sbearrows, #171)

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 
 # cpp11 0.2.7
 
+
+*Added `named()` and `empty()` methods to r_vector classes, returning true if named/empty (@sbearrows, #182, #186) 
 * Outputting more informative error message when cpp11 decorators are incorrectly formatted (@sbearrows, #127)
 * Fix spurious diffs from `tools::package_native_routine_registration_skeleton()` by temporarily using C collation (@sbearrows, #171)
 * Fix a transient memory leak for functions that return values from `cpp11::unwind_protect()` and `cpp11::safe` (#154)

--- a/cpp11test/src/test-list.cpp
+++ b/cpp11test/src/test-list.cpp
@@ -126,4 +126,15 @@ context("list-C++") {
     expect_true(first[0] == 1);
     expect_true(first[1] == 2);
   }
+
+  test_that("empty() works") {
+    cpp11::writable::list x;
+
+    expect_true(x.empty());
+
+    cpp11::writable::list y(1);
+
+    expect_false(y.empty());
+  }
+
 }

--- a/cpp11test/src/test-list.cpp
+++ b/cpp11test/src/test-list.cpp
@@ -132,5 +132,4 @@ context("list-C++") {
 
     expect_false(y.empty());
   }
-
 }

--- a/inst/include/cpp11/r_vector.hpp
+++ b/inst/include/cpp11/r_vector.hpp
@@ -396,7 +396,6 @@ inline bool r_vector<T>::empty() const {
   return (!(this->size() > 0));
 }
 
-
 template <typename T>
 inline r_vector<T>::operator sexp() const {
   return data_;

--- a/inst/include/cpp11/r_vector.hpp
+++ b/inst/include/cpp11/r_vector.hpp
@@ -112,6 +112,8 @@ class r_vector {
 
   operator sexp() const;
 
+  bool empty() const;
+
   /// Provide access to the underlying data, mainly for interface
   /// compatibility with std::vector
   SEXP data() const;
@@ -388,6 +390,12 @@ template <typename T>
 inline r_vector<T>::operator SEXP() const {
   return data_;
 }
+
+template <typename T>
+inline bool r_vector<T>::empty() const {
+  return (!(this->size() > 0));
+}
+
 
 template <typename T>
 inline r_vector<T>::operator sexp() const {


### PR DESCRIPTION
Added news updates for both `named()` and `empty()` to this PR

fixes #182 