### PR TITLE
Support more efficient nesting of unwind_protect

### DIFF
--- a/inst/include/cpp11/protect.hpp
+++ b/inst/include/cpp11/protect.hpp
@@ -399,5 +399,4 @@ static struct {
   SEXP list_ = get_preserve_list();
 }  // namespace cpp11
 preserved;
-
 }  // namespace cpp11

--- a/inst/include/cpp11/protect.hpp
+++ b/inst/include/cpp11/protect.hpp
@@ -78,7 +78,6 @@ static int* should_unwind_protect = get_should_unwind_protect();
 template <typename Fun, typename = typename std::enable_if<std::is_same<
                             decltype(std::declval<Fun&&>()()), SEXP>::value>::type>
 SEXP unwind_protect(Fun&& code) {
-  REprintf("%s\n", *detail::should_unwind_protect == TRUE ? "TRUE" : "FALSE");
   if (*detail::should_unwind_protect == FALSE) {
     return std::forward<Fun>(code)();
   }


### PR DESCRIPTION
The internal protection can be skipped if we are already in an
unwind_protect call.

Fixes #141