### PR TITLE
Fix compilation on R 3.3

### DIFF
--- a/inst/include/cpp11/r_vector.hpp
+++ b/inst/include/cpp11/r_vector.hpp
@@ -884,7 +884,7 @@ inline SEXP truncate(SEXP x, R_xlen_t length, R_xlen_t capacity) {
   SET_TRUELENGTH(x, capacity);
   SET_GROWABLE_BIT(x);
 #else
-  x = safe[Rf_lengthgets](x, length_);
+  x = safe[Rf_lengthgets](x, length);
 #endif
   return x;
 }


### PR DESCRIPTION
Looks like CI won't catch this since it only runs R >= 3.4, but logically this looks right to me.