### PR TITLE
Fix type_error when constructing integers & doubles

### DIFF
--- a/inst/include/cpp11/doubles.hpp
+++ b/inst/include/cpp11/doubles.hpp
@@ -148,7 +148,7 @@ inline doubles as_doubles(sexp x) {
     return ret;
   }
 
-  throw type_error(INTSXP, TYPEOF(x));
+  throw type_error(REALSXP, TYPEOF(x));
 }
 
 template <>

--- a/inst/include/cpp11/integers.hpp
+++ b/inst/include/cpp11/integers.hpp
@@ -163,7 +163,7 @@ inline integers as_integers(sexp x) {
     return ret;
   }
 
-  throw type_error(REALSXP, TYPEOF(x));
+  throw type_error(INTSXP, TYPEOF(x));
 }
 
 }  // namespace cpp11


### PR DESCRIPTION
I think it should mention REALSXP for doubles and INTSXP for integers when throwing type_error.