### PR TITLE
Fix crash related to unwind protect short circuiting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cpp11 (development version)
 
+* Fix crash related to unwind protect optimization (#244)
+
 # cpp11 0.4.0
 
 ## New Features


### PR DESCRIPTION
It seems relying on non-local static objects can cause memory issues,
that are resolved by moving to use a local static objects instead.

Fixes #244