### PR TITLE
Cpp source include fixes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # cpp11 (development version)
 
 * Type files `<basename>_type.h` is no honored by `source_cpp()` (#216). 
+* The directory of the sourced file is included into the include path during `source_cpp()` compilation. 
 
 # cpp11 0.4.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cpp11 (development version)
 
+* Type files `<basename>_type.h` is no honored by `source_cpp()` (#216). 
+
 # cpp11 0.4.1
 
 * Fix crash related to unwind protect optimization (#244)

--- a/R/source.R
+++ b/R/source.R
@@ -127,7 +127,8 @@ cpp_source <- function(file, code = NULL, env = parent.frame(), clean = TRUE, qu
 
   linking_to <- union(get_linking_to(all_decorations), "cpp11")
 
-  includes <- generate_include_paths(linking_to)
+  includes <- c(generate_include_paths(linking_to),
+                sprintf("-I'%s'", orig_dir))
 
   if (isTRUE(clean)) {
     on.exit(unlink(dir, recursive = TRUE), add = TRUE)

--- a/man/cpp11-package.Rd
+++ b/man/cpp11-package.Rd
@@ -6,11 +6,7 @@
 \alias{cpp11-package}
 \title{cpp11: A C++11 Interface for R's C Interface}
 \description{
-Provides a header only, C++11 interface to R's C
-    interface.  Compared to other approaches 'cpp11' strives to be safe
-    against long jumps from the C API as well as C++ exceptions, conform
-    to normal R function semantics and supports interaction with 'ALTREP'
-    vectors.
+Provides a header only, C++11 interface to R's C interface. Compared to other approaches 'cpp11' strives to be safe against long jumps from the C API as well as C++ exceptions, conform to normal R function semantics and supports interaction with 'ALTREP' vectors.
 }
 \seealso{
 Useful links:

--- a/man/cpp_source.Rd
+++ b/man/cpp_source.Rd
@@ -64,6 +64,10 @@ expression.
 Within C++ code you can use \verb{[[cpp11::linking_to("pkgxyz")]]} to link to
 external packages. This is equivalent to putting those packages in the
 \code{LinkingTo} field in a package DESCRIPTION.
+
+Custom types, if any,  should be declared in \verb{<basename>_types.h} or
+\verb{<basename>_types.hpp}. If such file exists it will be automatically included
+into the routine registration file (\code{cpp11.cpp}) during compilation.
 }
 \examples{
 


### PR DESCRIPTION
Two improvements to `srouce_cpp()`:

  - Honor `<basename>_types.h` or `<basename>_types.hpp` (I included both extensions because editor support might be different for different extensions. And I feel it's cleaner to use hpp for cpp code).  Fixes #216 
  - Add file's directory to the include path. (addresses most common use case of #246 without dealing with CPPFLAGS trickery) 