### PR TITLE
Fail fast and informatively for nonexistent file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cpp11 (development version)
 
+* `cpp_source()` errors on non-existent file (#261). 
+
 # cpp11 0.4.2
 
 * Romain François is now the maintainer.

--- a/R/source.R
+++ b/R/source.R
@@ -67,7 +67,7 @@
 #' @export
 cpp_source <- function(file, code = NULL, env = parent.frame(), clean = TRUE, quiet = TRUE, cxx_std = Sys.getenv("CXX_STD", "CXX11"), dir = tempfile()) {
   stop_unless_installed(c("brio", "callr", "cli", "decor", "desc", "glue", "tibble", "vctrs"))
-  if (!file.exists(file)) {
+  if (!missing(file) && !file.exists(file)) {
     stop("`file` must exist.", call. = FALSE)
   }
 

--- a/R/source.R
+++ b/R/source.R
@@ -68,7 +68,7 @@
 cpp_source <- function(file, code = NULL, env = parent.frame(), clean = TRUE, quiet = TRUE, cxx_std = Sys.getenv("CXX_STD", "CXX11"), dir = tempfile()) {
   stop_unless_installed(c("brio", "callr", "cli", "decor", "desc", "glue", "tibble", "vctrs"))
   if (!missing(file) && !file.exists(file)) {
-    stop("`file` must exist.", call. = FALSE)
+    stop("Can't find `file` at this path:\n", file, "\n", call. = FALSE)
   }
 
   dir.create(dir, showWarnings = FALSE, recursive = TRUE)

--- a/R/source.R
+++ b/R/source.R
@@ -67,6 +67,9 @@
 #' @export
 cpp_source <- function(file, code = NULL, env = parent.frame(), clean = TRUE, quiet = TRUE, cxx_std = Sys.getenv("CXX_STD", "CXX11"), dir = tempfile()) {
   stop_unless_installed(c("brio", "callr", "cli", "decor", "desc", "glue", "tibble", "vctrs"))
+  if (!file.exists(file)) {
+    stop("`file` must exist.", call. = FALSE)
+  }
 
   dir.create(dir, showWarnings = FALSE, recursive = TRUE)
   dir.create(file.path(dir, "R"), showWarnings = FALSE)

--- a/tests/testthat/_snaps/source.md
+++ b/tests/testthat/_snaps/source.md
@@ -1,0 +1,7 @@
+# cpp_source fails informatively for nonexistent file
+
+    Code
+      cpp_source(i_do_not_exist)
+    Error <simpleError>
+      non-character object(s)
+

--- a/tests/testthat/_snaps/source.md
+++ b/tests/testthat/_snaps/source.md
@@ -3,5 +3,6 @@
     Code
       cpp_source(i_do_not_exist)
     Error <simpleError>
-      `file` must exist.
+      Can't find `file` at this path:
+      {NON_EXISTENT_FILEPATH}
 

--- a/tests/testthat/_snaps/source.md
+++ b/tests/testthat/_snaps/source.md
@@ -3,5 +3,5 @@
     Code
       cpp_source(i_do_not_exist)
     Error <simpleError>
-      non-character object(s)
+      `file` must exist.
 

--- a/tests/testthat/test-source.R
+++ b/tests/testthat/test-source.R
@@ -217,3 +217,9 @@ test_that("cpp_source(d) functions work after sourcing file more than once", {
   cpp11::cpp_source(test_path("single.cpp"), clean = TRUE)
   expect_equal(foo(), 1)
 })
+
+test_that("cpp_source fails informatively for nonexistent file", {
+  i_do_not_exist <- tempfile(pattern = "nope-", fileext = ".cpp")
+  expect_false(file.exists(i_do_not_exist))
+  expect_snapshot(error = TRUE, cpp_source(i_do_not_exist))
+})

--- a/tests/testthat/test-source.R
+++ b/tests/testthat/test-source.R
@@ -221,5 +221,9 @@ test_that("cpp_source(d) functions work after sourcing file more than once", {
 test_that("cpp_source fails informatively for nonexistent file", {
   i_do_not_exist <- tempfile(pattern = "nope-", fileext = ".cpp")
   expect_false(file.exists(i_do_not_exist))
-  expect_snapshot(error = TRUE, cpp_source(i_do_not_exist))
+  expect_snapshot(
+    error = TRUE,
+    cpp_source(i_do_not_exist),
+    transform = ~ sub("^.+[.]cpp$", "{NON_EXISTENT_FILEPATH}", .x)
+  )
 })


### PR DESCRIPTION
If I call `cpp_source()` with a nonexistent filepath, interactively I see:

```
> devtools::load_all(".")
ℹ Loading cpp11
> cpp_source("asdfuiop.cpp")
Error in startsWith(decorations$decoration, "cpp11::") : 
  non-character object(s)
```

I'm not sure why the first snapshot in this PR shows a different (but also non informative) error. But, in any case, it seems better to check early for the existence of `file` and to fail in a more specific way, if `file` does not exist.