### PR TITLE
Ensure that `data_p_` is typed with the underlying type of `data_`

### DIFF
--- a/inst/include/cpp11/R.hpp
+++ b/inst/include/cpp11/R.hpp
@@ -33,6 +33,13 @@ constexpr R_xlen_t operator"" _xl(unsigned long long int value) { return value; 
 
 }  // namespace literals
 
+namespace traits {
+template <typename T>
+struct get_underlying_type {
+  using type = T;
+};
+}  // namespace traits
+
 template <typename T>
 inline T na();
 

--- a/inst/include/cpp11/doubles.hpp
+++ b/inst/include/cpp11/doubles.hpp
@@ -34,7 +34,8 @@ inline double r_vector<double>::operator[](const R_xlen_t pos) const {
 }
 
 template <>
-inline double* r_vector<double>::get_p(bool is_altrep, SEXP data) {
+inline typename r_vector<double>::underlying_type* r_vector<double>::get_p(bool is_altrep,
+                                                                           SEXP data) {
   if (is_altrep) {
     return nullptr;
   } else {

--- a/inst/include/cpp11/integers.hpp
+++ b/inst/include/cpp11/integers.hpp
@@ -35,7 +35,8 @@ inline int r_vector<int>::operator[](const R_xlen_t pos) const {
 }
 
 template <>
-inline int* r_vector<int>::get_p(bool is_altrep, SEXP data) {
+inline typename r_vector<int>::underlying_type* r_vector<int>::get_p(bool is_altrep,
+                                                                     SEXP data) {
   if (is_altrep) {
     return nullptr;
   } else {

--- a/inst/include/cpp11/list.hpp
+++ b/inst/include/cpp11/list.hpp
@@ -45,7 +45,7 @@ inline SEXP r_vector<SEXP>::operator[](const r_string& name) const {
 }
 
 template <>
-inline SEXP* r_vector<SEXP>::get_p(bool, SEXP) {
+inline typename r_vector<SEXP>::underlying_type* r_vector<SEXP>::get_p(bool, SEXP) {
   return nullptr;
 }
 

--- a/inst/include/cpp11/logicals.hpp
+++ b/inst/include/cpp11/logicals.hpp
@@ -29,22 +29,23 @@ inline SEXP r_vector<r_bool>::valid_type(SEXP data) {
 
 template <>
 inline r_bool r_vector<r_bool>::operator[](const R_xlen_t pos) const {
-  return is_altrep_ ? static_cast<r_bool>(LOGICAL_ELT(data_, pos)) : data_p_[pos];
+  return is_altrep_ ? LOGICAL_ELT(data_, pos) : data_p_[pos];
 }
 
 template <>
-inline r_bool* r_vector<r_bool>::get_p(bool is_altrep, SEXP data) {
+inline typename r_vector<r_bool>::underlying_type* r_vector<r_bool>::get_p(bool is_altrep,
+                                                                           SEXP data) {
   if (is_altrep) {
     return nullptr;
   } else {
-    return reinterpret_cast<r_bool*>(LOGICAL(data));
+    return LOGICAL(data);
   }
 }
 
 template <>
 inline void r_vector<r_bool>::const_iterator::fill_buf(R_xlen_t pos) {
   length_ = std::min(64_xl, data_->size() - pos);
-  LOGICAL_GET_REGION(data_->data_, pos, length_, reinterpret_cast<int*>(buf_.data()));
+  LOGICAL_GET_REGION(data_->data_, pos, length_, buf_.data());
   block_start_ = pos;
 }
 
@@ -66,7 +67,7 @@ inline typename r_vector<r_bool>::proxy& r_vector<r_bool>::proxy::operator=(
 template <>
 inline r_vector<r_bool>::proxy::operator r_bool() const {
   if (p_ == nullptr) {
-    return static_cast<r_bool>(LOGICAL_ELT(data_, index_));
+    return LOGICAL_ELT(data_, index_);
   } else {
     return *p_;
   }
@@ -100,7 +101,7 @@ inline r_vector<r_bool>::r_vector(std::initializer_list<named_arg> il)
       ++n_protected;
       auto it = il.begin();
       for (R_xlen_t i = 0; i < capacity_; ++i, ++it) {
-        data_p_[i] = static_cast<r_bool>(LOGICAL_ELT(it->value(), 0));
+        data_p_[i] = LOGICAL_ELT(it->value(), 0);
         SET_STRING_ELT(names, i, Rf_mkCharCE(it->name(), CE_UTF8));
       }
       UNPROTECT(n_protected);
@@ -121,7 +122,7 @@ inline void r_vector<r_bool>::reserve(R_xlen_t new_capacity) {
 
   preserved.release(old_protect);
 
-  data_p_ = reinterpret_cast<r_bool*>(LOGICAL(data_));
+  data_p_ = LOGICAL(data_);
   capacity_ = new_capacity;
 }
 

--- a/inst/include/cpp11/r_bool.hpp
+++ b/inst/include/cpp11/r_bool.hpp
@@ -71,4 +71,11 @@ inline r_bool na() {
   return NA_LOGICAL;
 }
 
+namespace traits {
+template <>
+struct get_underlying_type<r_bool> {
+  using type = int;
+};
+}  // namespace traits
+
 }  // namespace cpp11

--- a/inst/include/cpp11/r_string.hpp
+++ b/inst/include/cpp11/r_string.hpp
@@ -93,4 +93,11 @@ inline r_string na() {
   return NA_STRING;
 }
 
+namespace traits {
+template <>
+struct get_underlying_type<r_string> {
+  using type = SEXP;
+};
+}  // namespace traits
+
 }  // namespace cpp11

--- a/inst/include/cpp11/raws.hpp
+++ b/inst/include/cpp11/raws.hpp
@@ -16,6 +16,13 @@
 
 namespace cpp11 {
 
+namespace traits {
+template <>
+struct get_underlying_type<uint8_t> {
+  using type = Rbyte;
+};
+}  // namespace traits
+
 template <>
 inline SEXP r_vector<uint8_t>::valid_type(SEXP data) {
   if (data == nullptr) {
@@ -34,11 +41,12 @@ inline uint8_t r_vector<uint8_t>::operator[](const R_xlen_t pos) const {
 }
 
 template <>
-inline uint8_t* r_vector<uint8_t>::get_p(bool is_altrep, SEXP data) {
+inline typename r_vector<uint8_t>::underlying_type* r_vector<uint8_t>::get_p(
+    bool is_altrep, SEXP data) {
   if (is_altrep) {
     return nullptr;
   } else {
-    return reinterpret_cast<uint8_t*>(RAW(data));
+    return RAW(data);
   }
 }
 
@@ -46,8 +54,7 @@ template <>
 inline void r_vector<uint8_t>::const_iterator::fill_buf(R_xlen_t pos) {
   using namespace cpp11::literals;
   length_ = std::min(64_xl, data_->size() - pos);
-  unwind_protect(
-      [&] { RAW_GET_REGION(data_->data_, pos, length_, (uint8_t*)buf_.data()); });
+  unwind_protect([&] { RAW_GET_REGION(data_->data_, pos, length_, buf_.data()); });
   block_start_ = pos;
 }
 
@@ -124,7 +131,7 @@ inline void r_vector<uint8_t>::reserve(R_xlen_t new_capacity) {
   protect_ = preserved.insert(data_);
   preserved.release(old_protect);
 
-  data_p_ = reinterpret_cast<uint8_t*>(RAW(data_));
+  data_p_ = RAW(data_);
   capacity_ = new_capacity;
 }
 

--- a/inst/include/cpp11/strings.hpp
+++ b/inst/include/cpp11/strings.hpp
@@ -34,7 +34,8 @@ inline r_string r_vector<r_string>::operator[](const R_xlen_t pos) const {
 }
 
 template <>
-inline r_string* r_vector<r_string>::get_p(bool, SEXP) {
+inline typename r_vector<r_string>::underlying_type* r_vector<r_string>::get_p(bool,
+                                                                               SEXP) {
   return nullptr;
 }
 


### PR DESCRIPTION
This PR attempts to force `data_p_` to always be a pointer to the "underlying" type of `SEXP data_`.

Currently, this is not the case. `data_p_` currently has type `T*`, which means that for various vectors it maps to:

- integers: `int*`
- doubles: `double*`
- logicals: `r_bool*` (rather than `int*`)
- raws: `uint8_t*` (rather than `Rbyte*`)
- list: not used, but would be `SEXP*`
- strings: not used, but would be `r_string*` (rather than `SEXP*`)
- complexes: not implemented (yet!, but it is built on top of this here https://github.com/DavisVaughan/cpp11/pull/2)

The `logicals` and `raws` cases make me a little nervous. When `data_p_` is set for these classes, it is done so like:

```cpp
data_p_ = reinterpret_cast<r_bool*>(LOGICAL(data))
```

I think we can avoid this by instead ensuring that `data_p_` has type `int*` here, and is just set to `LOGICAL(data)`. Then we rely on casts from `r_bool` to `int` and vice versa when setting and getting elements.

I think it definitely cleaned up `logicals.hpp` and `raws.hpp` nicely, as some intermediate `static_cast()` and `reinterpret_cast()` calls were removed.

I'm also not _entirely_ sure how this `reinterpret_cast()` is currently working, but I assume it works because `r_bool` just has 1 variable member, `int value_`, which is the same size as an `int` that we'd get from the `int*`? Nevertheless, this new approach feels safer and easier to understand to me.

---

The general idea of this PR is to introduce a compile time "underlying" type that we can deduce from `T`. The default is just `T`, which works for `int` and `double`, but this is overridden for `r_bool` and `uint8_t`.

We then use this underlying type for the buffer (`buf_`) and for the pointer type.

---

This PR should have other benefits too. I am working on adding complexes, and I think I will use an `r_complex` intermediate type which will also define a custom underlying type, like:

```cpp
namespace traits {
template <>
struct get_underlying_type<r_complex> { using type = Rcomplex; };
}  // namespace traits
```

Additionally, for read-only lists and character vectors, we _could_ set the `data_p_` to `DATAPTR()`, like we do in vctrs https://github.com/r-lib/vctrs/blob/7260d31a31b87ece16c7bbda3521e91d1c0f242f/src/vctrs-core.h#L97. This could provide much faster access, since we don't have to go through `VECTOR_ELT()`, and should be safe for read-only access. That would require the `get_underlying_type<r_string>` I've added here (it currently goes unused).