### PR TITLE
Allow passing number of rows from outside

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # cpp11 (development version)
 
+* New `writable::data_frame` constructor that also takes the number of rows as
+  input. This accounts for the edge case where the input list has 0 columns but
+  you'd still like to specify a known number of rows (#272).
+
 * `cpp11::writable::r_vector<T>::iterator` no longer implicitly deletes its
   copy assignment operator (#360).
 

--- a/cpp11test/src/test-data_frame.cpp
+++ b/cpp11test/src/test-data_frame.cpp
@@ -43,6 +43,28 @@ context("data_frame-C++") {
     expect_true(df.nrow() == 10);
   }
 
+  test_that("writable::data_frame::nrow works with 0x0 dfs") {
+    SEXP x = PROTECT(Rf_allocVector(VECSXP, 0));
+
+    cpp11::writable::data_frame df(x);
+    expect_true(df.nrow() == 0);
+
+    UNPROTECT(1);
+  }
+
+  test_that("writable::data_frame::nrow works with 10x0 dfs (#272)") {
+    SEXP x = PROTECT(Rf_allocVector(VECSXP, 0));
+
+    bool is_altrep = false;
+    int nrow = 10;
+
+    // Manually specify `nrow` using special constructor
+    cpp11::writable::data_frame df(x, is_altrep, nrow);
+    expect_true(df.nrow() == 10);
+
+    UNPROTECT(1);
+  }
+
   test_that("writable::data_frame works") {
     using namespace cpp11::literals;
     cpp11::writable::data_frame df({"x"_nm = {1, 2, 3}, "y"_nm = {"a", "b", "c"}});

--- a/inst/include/cpp11/data_frame.hpp
+++ b/inst/include/cpp11/data_frame.hpp
@@ -66,16 +66,18 @@ class data_frame : public list {
 namespace writable {
 class data_frame : public cpp11::data_frame {
  private:
-  writable::list set_data_frame_attributes(writable::list&& x) {
-    x.attr(R_RowNamesSymbol) = {NA_INTEGER, -static_cast<int>(calc_nrow(x))};
+  writable::list set_data_frame_attributes(writable::list&& x, int nrow) {
+    x.attr(R_RowNamesSymbol) = {NA_INTEGER, -nrow};
     x.attr(R_ClassSymbol) = "data.frame";
     return std::move(x);
   }
 
  public:
-  data_frame(const SEXP data) : cpp11::data_frame(set_data_frame_attributes(data)) {}
+  data_frame(const SEXP data) : cpp11::data_frame(set_data_frame_attributes(data, calc_nrow(data))) {}
   data_frame(const SEXP data, bool is_altrep)
       : cpp11::data_frame(set_data_frame_attributes(data), is_altrep) {}
+  data_frame(const SEXP data, bool is_altrep, int nrow)
+    : cpp11::data_frame(set_data_frame_attributes(data, nrow), is_altrep) {}
   data_frame(std::initializer_list<list> il)
       : cpp11::data_frame(set_data_frame_attributes(writable::list(il))) {}
   data_frame(std::initializer_list<named_arg> il)

--- a/inst/include/cpp11/data_frame.hpp
+++ b/inst/include/cpp11/data_frame.hpp
@@ -77,11 +77,12 @@ class data_frame : public cpp11::data_frame {
   }
 
  public:
-  data_frame(const SEXP data) : cpp11::data_frame(set_data_frame_attributes(data, calc_nrow(data))) {}
+  data_frame(const SEXP data)
+      : cpp11::data_frame(set_data_frame_attributes(data, calc_nrow(data))) {}
   data_frame(const SEXP data, bool is_altrep)
       : cpp11::data_frame(set_data_frame_attributes(data), is_altrep) {}
   data_frame(const SEXP data, bool is_altrep, int nrow)
-    : cpp11::data_frame(set_data_frame_attributes(data, nrow), is_altrep) {}
+      : cpp11::data_frame(set_data_frame_attributes(data, nrow), is_altrep) {}
   data_frame(std::initializer_list<list> il)
       : cpp11::data_frame(set_data_frame_attributes(writable::list(il))) {}
   data_frame(std::initializer_list<named_arg> il)

--- a/inst/include/cpp11/data_frame.hpp
+++ b/inst/include/cpp11/data_frame.hpp
@@ -77,8 +77,7 @@ class data_frame : public cpp11::data_frame {
   }
 
  public:
-  data_frame(const SEXP data)
-      : cpp11::data_frame(set_data_frame_attributes(data, calc_nrow(data))) {}
+  data_frame(const SEXP data) : cpp11::data_frame(set_data_frame_attributes(data)) {}
   data_frame(const SEXP data, bool is_altrep)
       : cpp11::data_frame(set_data_frame_attributes(data), is_altrep) {}
   data_frame(const SEXP data, bool is_altrep, int nrow)

--- a/inst/include/cpp11/data_frame.hpp
+++ b/inst/include/cpp11/data_frame.hpp
@@ -66,6 +66,10 @@ class data_frame : public list {
 namespace writable {
 class data_frame : public cpp11::data_frame {
  private:
+  writable::list set_data_frame_attributes(writable::list&& x) {
+    return set_data_frame_attributes(std::move(x), calc_nrow(x));
+  }
+
   writable::list set_data_frame_attributes(writable::list&& x, int nrow) {
     x.attr(R_RowNamesSymbol) = {NA_INTEGER, -nrow};
     x.attr(R_ClassSymbol) = "data.frame";


### PR DESCRIPTION
The internal calc_nrow() doesn't (want to) implement the full vctrs logic, this offers a way for callers to construct a valid data frame in all corner cases.