### PR TITLE
Use Intel specific pragma to disable unknown attribute warning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # cpp11 (development version)
 
-* Silenced an unknown attribute warning specific to the Intel compiler (r-lib/systemfonts#98).
+* Silenced an unknown attribute warning specific to the Intel compiler
+  (r-lib/systemfonts#98).
 
 # cpp11 0.4.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cpp11 (development version)
 
+* Silenced an unknown attribute warning specific to the Intel compiler (#98).
+
 # cpp11 0.4.3
 
 * Modernized the GitHub Actions workflows and updated some internal tests to

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # cpp11 (development version)
 
-* Silenced an unknown attribute warning specific to the Intel compiler (#98).
+* Silenced an unknown attribute warning specific to the Intel compiler (r-lib/systemfonts#98).
 
 # cpp11 0.4.3
 

--- a/inst/include/cpp11/R.hpp
+++ b/inst/include/cpp11/R.hpp
@@ -13,12 +13,16 @@
 #include "Rinternals.h"
 
 // clang-format off
-#ifdef __clang__
+#if defined(__INTEL_COMPILER)
+# pragma warning(disable : 3924)
+#endif
+
+#if defined(__clang__)
 # pragma clang diagnostic push
 # pragma clang diagnostic ignored "-Wattributes"
 #endif
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wattributes"
 #endif


### PR DESCRIPTION
See https://github.com/r-lib/systemfonts/issues/98 for the original issue. That issue turned out to be a different _error_, but this PR still silences the _warning_ that appeared there. The original issue poster confirmed that this PR fixed the warning.

---

On the Intel compiler (icpc), it looks like our pragmas to disable unknown attribute warnings are not working, i.e. in the original issue the user saw:

```cpp
In file included from caches.cpp(1):
caches.h(22): warning #3924: attribute namespace "cpp11" is unrecognized
  [[cpp11::init]]
```

On the Intel compiler, it looks like you disable warnings using the diagnostic number instead, in this case that is the `#3924` you see in the warning output above. The following two resources support this. In particular, the second resource disables the exact warning that we are also trying to disable, so it serves as a good reference:
- https://community.intel.com/t5/Intel-C-Compiler/how-to-ignore-deprecated-warning/td-p/1072843
- https://github.com/softwareQinc/qpp/blob/55b8184b98559233d9fb439ba78a517893380f89/include/qpp.h#L42-L62

To detect the Intel compiler, we need to look for `__INTEL_COMPILER`. But it seems like the Intel compiler also defines `__GNUC__`, so I've tweaked the defines a little to reflect that. See the `GCC C/C++` and `Intel C/C++` sections of the following resource:
- https://sourceforge.net/p/predef/wiki/Compilers/