### PR TITLE
Switch to bootstrap 5 for pkgdown website

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,6 +47,7 @@ Suggests:
     withr
 VignetteBuilder: 
     knitr
+Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Config/Needs/cpp11/cpp_register: 
     brio,

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -4,6 +4,14 @@ authors:
   "Jim Hester":
     href: http://jimhester.com
 
+template:
+  package: tidytemplate
+  bootstrap: 5
+
+  includes:
+    in_header: |
+      <script defer data-domain="cpp11.r-lib.org,all.tidyverse.org" src="https://plausible.io/js/plausible.js"></script>
+
 development:
   mode: auto
 


### PR DESCRIPTION
For two reasons:

- To be consistent with other r-lib pkgdown websites
- To make it easy for users to search for information

<img width="293" alt="Screenshot 2022-09-13 at 09 46 55" src="https://user-images.githubusercontent.com/11330453/189842164-174ac1b4-d774-461f-a9ff-7633d4866a8b.png">

cc @romainfrancois 
