### PR TITLE
`cpp_register(quiet=)` set to TRUE on non-interactive session (incl testthat runs)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,7 +58,7 @@ Config/Needs/cpp11/cpp_register:
     vctrs
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 SystemRequirements: C++11
 Remotes:
     r-lib/testthat@ad8b726d1734c59ed08ec7d11df4a3d76d8e69df

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * `cpp_source()` errors on non-existent file (#261). 
 
+* `cpp_register()` is quiet by default when R is non interactive.
+
 # cpp11 0.4.2
 
 * Romain François is now the maintainer.

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 * `cpp_source()` errors on non-existent file (#261). 
 
-* `cpp_register()` is quiet by default when R is non interactive.
+* `cpp_register()` is quiet by default when R is non interactive (#289).
 
 # cpp11 0.4.2
 

--- a/R/register.R
+++ b/R/register.R
@@ -34,7 +34,7 @@
 #'
 #' # cleanup
 #' unlink(dir, recursive = TRUE)
-cpp_register <- function(path = ".", quiet = FALSE) {
+cpp_register <- function(path = ".", quiet = !is_interactive()) {
   stop_unless_installed(get_cpp_register_needs())
 
   r_path <- file.path(path, "R", "cpp11.R")
@@ -138,7 +138,7 @@ cpp_register <- function(path = ".", quiet = FALSE) {
 
 utils::globalVariables(c("name", "return_type", "line", "decoration", "context", ".", "functions", "res"))
 
-get_registered_functions <- function(decorations, tag, quiet = FALSE) {
+get_registered_functions <- function(decorations, tag, quiet = !is_interactive()) {
   if (NROW(decorations) == 0) {
     return(tibble::tibble(file = character(), line = integer(), decoration = character(), params = list(), context = list(), name = character(), return_type = character(), args = list()))
   }

--- a/R/source.R
+++ b/R/source.R
@@ -109,9 +109,7 @@ cpp_source <- function(file, code = NULL, env = parent.frame(), clean = TRUE, qu
   #provide original path for error messages
   check_valid_attributes(all_decorations, file = orig_file_path)
 
-  cli_suppress(
-    funs <- get_registered_functions(all_decorations, "cpp11::register", quiet = quiet)
-  )
+  funs <- get_registered_functions(all_decorations, "cpp11::register", quiet = quiet)
   cpp_functions_definitions <- generate_cpp_functions(funs, package = package)
 
   cpp_path <- file.path(dirname(new_file_path), "cpp11.cpp")

--- a/R/source.R
+++ b/R/source.R
@@ -110,7 +110,7 @@ cpp_source <- function(file, code = NULL, env = parent.frame(), clean = TRUE, qu
   check_valid_attributes(all_decorations, file = orig_file_path)
 
   cli_suppress(
-    funs <- get_registered_functions(all_decorations, "cpp11::register")
+    funs <- get_registered_functions(all_decorations, "cpp11::register", quiet = quiet)
   )
   cpp_functions_definitions <- generate_cpp_functions(funs, package = package)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,12 +1,3 @@
-cli_suppress <- function(expr) {
-  withCallingHandlers(
-    expr,
-    cli_message = function(c) {
-      invokeRestart("cli_message_handled")
-    }
-  )
-}
-
 glue_collapse_data <- function(data, ..., sep = ", ", last = "") {
   res <- glue::glue_collapse(glue::glue_data(data, ...), sep = sep, last = last)
   if (length(res) == 0) {

--- a/man/cpp_register.Rd
+++ b/man/cpp_register.Rd
@@ -4,7 +4,7 @@
 \alias{cpp_register}
 \title{Generates wrappers for registered C++ functions}
 \usage{
-cpp_register(path = ".", quiet = FALSE)
+cpp_register(path = ".", quiet = !is_interactive())
 }
 \arguments{
 \item{path}{The path to the package root directory}

--- a/tests/testthat/_snaps/register.md
+++ b/tests/testthat/_snaps/register.md
@@ -1,0 +1,9 @@
+# cpp_register: can be run with messages
+
+    Code
+      cpp_register(p, quiet = FALSE)
+    Message <cliMessage>
+      ℹ 1 functions decorated with [[cpp11::register]]
+      ✔ generated file ']8;;file:///Users/romainfrancois/git/cpp11/tests/testthat/cpp11.Rcpp11.R]8;;'
+      ✔ generated file ']8;;file:///Users/romainfrancois/git/cpp11/tests/testthat/cpp11.cppcpp11.cpp]8;;'
+

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -14,7 +14,7 @@ pkg_path <- function(pkg) {
 
 get_funs <- function(path) {
   all_decorations <- decor::cpp_decorations(path, is_attribute = TRUE)
-  get_registered_functions(all_decorations, "cpp11::register", quiet = FALSE)
+  get_registered_functions(all_decorations, "cpp11::register", quiet = TRUE)
 }
 
 get_package_name <- function(path) {

--- a/tests/testthat/test-register.R
+++ b/tests/testthat/test-register.R
@@ -614,12 +614,18 @@ extern \"C\" attribute_visible void R_init_testPkg(DllInfo* dll){
   })
 
 
-  it("can be run with messages, by default", {
+  it("can be run with messages", {
     pkg <- local_package()
     p <- pkg_path(pkg)
     dir.create(file.path(p, "src"))
     file.copy(test_path("single.cpp"), file.path(p, "src", "single.cpp"))
-    expect_message(cpp_register(p), "1 functions decorated with [[cpp11::register]]", fixed = TRUE)
+    suppressMessages(
+      # cpp_register() sends 3 messages, but expect_message() only checks
+      # for one, so suppress the other ones, so that they don't appear in the
+      # testthat output
+      expect_message(
+        cpp_register(p, quiet = FALSE), "1 functions decorated with [[cpp11::register]]", fixed = TRUE)
+    )
   })
 
   it("includes pkg_types.h if included in src", {

--- a/tests/testthat/test-register.R
+++ b/tests/testthat/test-register.R
@@ -619,12 +619,9 @@ extern \"C\" attribute_visible void R_init_testPkg(DllInfo* dll){
     p <- pkg_path(pkg)
     dir.create(file.path(p, "src"))
     file.copy(test_path("single.cpp"), file.path(p, "src", "single.cpp"))
-    suppressMessages(
-      # cpp_register() sends 3 messages, but expect_message() only checks
-      # for one, so suppress the other ones, so that they don't appear in the
-      # testthat output
-      expect_message(
-        cpp_register(p, quiet = FALSE), "1 functions decorated with [[cpp11::register]]", fixed = TRUE)
+
+    expect_snapshot(
+      cpp_register(p, quiet = FALSE)
     )
   })
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,11 +1,3 @@
-describe("cli_suppress", {
-  it("suppresses cli outputs", {
-    f <- function() cli::cli_text("hi")
-    expect_message(f(), "hi")
-    expect_message(cli_suppress(f()), NA)
-  })
-})
-
 describe("glue_collapse_data", {
   it("works with empty inputs", {
     expect_equal(


### PR DESCRIPTION
So that e.g. the testthat output is less verbose: 

<img width="458" alt="image" src="https://user-images.githubusercontent.com/2625526/194839548-40383ff5-0849-4e3a-8fdb-00384fabb53c.png">
