### PR TITLE
`.Call()` entries might have `(void)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * `cpp_source()` errors on non-existent file (#261). 
 
+* updated test to adapt to changes in R 4.2.1 (#290).
+
 # cpp11 0.4.2
 
 * Romain François is now the maintainer.

--- a/tests/testthat/test-register.R
+++ b/tests/testthat/test-register.R
@@ -59,6 +59,7 @@ describe("get_call_entries", {
     dir.create(file.path(path, "R"))
     writeLines('foo <- function() .Call("bar")', file.path(path, "R", "foo.R"))
     call_entries <- get_call_entries(path, get_funs(path)$name, get_package_name(path))
+    # R added `(void)` to the signature after R 4.2.1
     expect_match(call_entries[2], "extern SEXP bar[(](void)?[)]")
     expect_equal(
       call_entries[4:7],

--- a/tests/testthat/test-register.R
+++ b/tests/testthat/test-register.R
@@ -58,12 +58,11 @@ describe("get_call_entries", {
     path <- pkg_path(pkg)
     dir.create(file.path(path, "R"))
     writeLines('foo <- function() .Call("bar")', file.path(path, "R", "foo.R"))
+    call_entries <- get_call_entries(path, get_funs(path)$name, get_package_name(path))
+    expect_match(call_entries[2], "extern SEXP bar[(](void)?[)]")
     expect_equal(
-      get_call_entries(path, get_funs(path)$name, get_package_name(path)),
-      c("/* .Call calls */",
-        "extern SEXP bar();",
-        "",
-        "static const R_CallMethodDef CallEntries[] = {",
+      call_entries[4:7],
+      c("static const R_CallMethodDef CallEntries[] = {",
         "    {\"bar\", (DL_FUNC) &bar, 0},",
         "    {NULL, NULL, 0}",
         "};"


### PR DESCRIPTION
since https://github.com/r-devel/r-svn/commit/acd91c3a24923e42562f5b663a64d389e7e06997

in response to cran email:

```
Dear maintainer,

Please see the problems shown on
<https://www.google.com/url?q=https://cran.r-project.org/web/checks/check_results_cpp11.html&source=gmail-imap&ust=1665988745000000&usg=AOvVaw0TUXx2J7KBy_EgFalrLd2O>.

Please correct before 2022-10-24 to safely retain your package on CRAN.

The CRAN Team
```

