### PR TITLE
Move `static` local variable out of templated function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cpp11 (development version)
 
+* Fixed a performance issue related to nested `unwind_protect()` calls (#298).
+
 # cpp11 0.4.3
 
 * Modernized the GitHub Actions workflows and updated some internal tests to

--- a/inst/include/cpp11/protect.hpp
+++ b/inst/include/cpp11/protect.hpp
@@ -54,20 +54,36 @@ inline void set_option(SEXP name, SEXP value) {
   SETCAR(opt, value);
 }
 
-inline Rboolean& get_should_unwind_protect() {
+inline Rboolean* setup_should_unwind_protect() {
   SEXP should_unwind_protect_sym = Rf_install("cpp11_should_unwind_protect");
   SEXP should_unwind_protect_sexp = Rf_GetOption1(should_unwind_protect_sym);
+
   if (should_unwind_protect_sexp == R_NilValue) {
+    // Allocate and initialize once, then let R manage it.
+    // That makes this a shared global across all compilation units.
     should_unwind_protect_sexp = PROTECT(Rf_allocVector(LGLSXP, 1));
+    SET_LOGICAL_ELT(should_unwind_protect_sexp, 0, TRUE);
     detail::set_option(should_unwind_protect_sym, should_unwind_protect_sexp);
     UNPROTECT(1);
   }
 
-  Rboolean* should_unwind_protect =
-      reinterpret_cast<Rboolean*>(LOGICAL(should_unwind_protect_sexp));
-  should_unwind_protect[0] = TRUE;
+  return reinterpret_cast<Rboolean*>(LOGICAL(should_unwind_protect_sexp));
+}
 
-  return should_unwind_protect[0];
+inline Rboolean* access_should_unwind_protect() {
+  // Setup is run once per compilation unit, but all compilation units
+  // share the same global option, so each compilation unit's static pointer
+  // will point to the same object.
+  static Rboolean* p_should_unwind_protect = setup_should_unwind_protect();
+  return p_should_unwind_protect;
+}
+
+inline Rboolean get_should_unwind_protect() {
+  return *access_should_unwind_protect();
+}
+
+inline void set_should_unwind_protect(Rboolean should_unwind_protect) {
+  *access_should_unwind_protect() = should_unwind_protect;
 }
 
 }  // namespace detail
@@ -80,12 +96,11 @@ inline Rboolean& get_should_unwind_protect() {
 template <typename Fun, typename = typename std::enable_if<std::is_same<
                             decltype(std::declval<Fun&&>()()), SEXP>::value>::type>
 SEXP unwind_protect(Fun&& code) {
-  static auto should_unwind_protect = detail::get_should_unwind_protect();
-  if (should_unwind_protect == FALSE) {
+  if (detail::get_should_unwind_protect() == FALSE) {
     return std::forward<Fun>(code)();
   }
 
-  should_unwind_protect = FALSE;
+  detail::set_should_unwind_protect(FALSE);
 
   static SEXP token = [] {
     SEXP res = R_MakeUnwindCont();
@@ -95,7 +110,7 @@ SEXP unwind_protect(Fun&& code) {
 
   std::jmp_buf jmpbuf;
   if (setjmp(jmpbuf)) {
-    should_unwind_protect = TRUE;
+    detail::set_should_unwind_protect(TRUE);
     throw unwind_exception(token);
   }
 
@@ -120,7 +135,7 @@ SEXP unwind_protect(Fun&& code) {
   // unset it here before returning the value ourselves.
   SETCAR(token, R_NilValue);
 
-  should_unwind_protect = TRUE;
+  detail::set_should_unwind_protect(TRUE);
 
   return res;
 }

--- a/inst/include/cpp11/protect.hpp
+++ b/inst/include/cpp11/protect.hpp
@@ -78,9 +78,7 @@ inline Rboolean* access_should_unwind_protect() {
   return p_should_unwind_protect;
 }
 
-inline Rboolean get_should_unwind_protect() {
-  return *access_should_unwind_protect();
-}
+inline Rboolean get_should_unwind_protect() { return *access_should_unwind_protect(); }
 
 inline void set_should_unwind_protect(Rboolean should_unwind_protect) {
   *access_should_unwind_protect() = should_unwind_protect;


### PR DESCRIPTION
Closes #298 

@jimhester would you mind reviewing this for me? You are the last one to have touched this code, and probably understand it better than anyone else. The #298 issue provides the backstory.

A rerun of the benchmark in #298 gives me:

```r
# Main
bench::mark(test(x), test2(x), iterations = 20)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 test(x)    715.35ms 751.55ms      1.31    7.63MB     1.96
#> 2 test2(x)     7.65ms   9.11ms    100.      7.63MB    35.1

# This PR
bench::mark(test(x), test2(x), iterations = 20)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 test(x)     69.13ms  79.75ms      11.7    7.63MB     17.5
#> 2 test2(x)     7.47ms   9.34ms      98.1    7.63MB     34.3
```

Which better matches the performance we had in 0.4.0

```r
# cpp11 0.4.0
bench::mark(test(x), test2(x), iterations = 20)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 test(x)     63.56ms   76.4ms      12.1    7.63MB     18.1
#> 2 test2(x)     7.19ms    8.3ms     103.     7.63MB     36.1
```

I also confirmed that I can't reproduce the original issue in https://github.com/r-lib/cpp11/issues/244 that forced us to move away from a global static variable.

FWIW the pattern I've used here is fairly similar to what is done in `<date>` to determine the tzdb file path
https://github.com/HowardHinnant/date/blob/22ceabf205d8d678710a43154da5a06b701c5830/src/tz.cpp#L394-L429