### PR TITLE
FIX: list_of operator[] missing const modifiers.

### DIFF
--- a/inst/include/cpp11/list_of.hpp
+++ b/inst/include/cpp11/list_of.hpp
@@ -13,14 +13,14 @@ class list_of : public list {
   list_of(const list& data) : list(data) {}
 
 #ifdef LONG_VECTOR_SUPPORT
-  T operator[](int pos) { return operator[](static_cast<R_xlen_t>(pos)); }
+  T operator[](int pos) const { return operator[](static_cast<R_xlen_t>(pos)); }
 #endif
 
-  T operator[](R_xlen_t pos) { return list::operator[](pos); }
+  T operator[](R_xlen_t pos) const { return list::operator[](pos); }
 
-  T operator[](const char* pos) { return list::operator[](pos); }
+  T operator[](const char* pos) const { return list::operator[](pos); }
 
-  T operator[](const std::string& pos) { return list::operator[](pos.c_str()); }
+  T operator[](const std::string& pos) const { return list::operator[](pos.c_str()); }
 };
 
 namespace writable {


### PR DESCRIPTION
Read only version of list_of operator[] functions was missing const modifiers.  As a result, when trying to access list elements, 1. const list_of ends up calling list's operator[] functions thus without auto type conversion, and 2 if forcing to use list_of::operator[],  we encounter compiler error that the call "discards const-ness". 