### PR TITLE
Minor fix about markdown syntax on cpp11.Rmd

### DIFF
--- a/vignettes/cpp11.Rmd
+++ b/vignettes/cpp11.Rmd
@@ -527,7 +527,9 @@ doubles attribs() {
 
 ## Missing values {#na}
 If you're working with missing values, you need to know two things:
+
 * How R's missing values behave in C++'s scalars (e.g., `double`).
+
 * How to get and set missing values in vectors (e.g., `doubles`).
 
 ### Scalars


### PR DESCRIPTION
Fix this on https://cpp11.r-lib.org/articles/cpp11.html#na:

![image](https://user-images.githubusercontent.com/1978793/218238554-fe813ecd-7e50-4d2f-923d-2d408e2cc37f.png)
