### PR TITLE
Fix minor formatting issue in cpp11 vignette

### DIFF
--- a/vignettes/cpp11.Rmd
+++ b/vignettes/cpp11.Rmd
@@ -527,6 +527,7 @@ doubles attribs() {
 
 ## Missing values {#na}
 If you're working with missing values, you need to know two things:
+
 * How R's missing values behave in C++'s scalars (e.g., `double`).
 * How to get and set missing values in vectors (e.g., `doubles`).
 


### PR DESCRIPTION
I found a very minor thing in the cp11 vignette in the Missing values section. Markdown renders need lists to have a preceding blank line in order to render properly.

Before this change, the corresponding text rendered like:

> If you’re working with missing values, you need to know two things: * How R’s missing values behave in C++’s scalars (e.g., double). * How to get and set missing values in vectors (e.g., doubles).

After:

> If you’re working with missing values, you need to know two things:
>
> * How R’s missing values behave in C++’s scalars (e.g., double).
> * How to get and set missing values in vectors (e.g., doubles).

I made a guess the current rendering wasn't intentional but feel free to close if it was.