### PR TITLE
Respond to upcoming changes in `glue::glue_collapse()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,6 @@ Suggests:
     decor,
     desc,
     ggplot2,
-    glue,
     knitr,
     lobstr,
     mockery,
@@ -61,3 +60,7 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1
 SystemRequirements: C++11
+Imports: 
+    glue (>= 1.6.2.9000)
+Remotes:  
+    tidyverse/glue@empty-glue-collapse

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,7 @@ Suggests:
     decor,
     desc,
     ggplot2,
+    glue,
     knitr,
     lobstr,
     mockery,
@@ -60,7 +61,3 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1
 SystemRequirements: C++11
-Imports: 
-    glue (>= 1.6.2.9000)
-Remotes:  
-    tidyverse/glue@empty-glue-collapse

--- a/R/register.R
+++ b/R/register.R
@@ -273,7 +273,7 @@ get_call_entries <- function(path, names, package) {
 
   redundant <- glue::glue_collapse(glue::glue('extern SEXP _{package}_{names}'), sep = '|')
 
-  if (length(redundant) > 0) {
+  if (length(redundant) > 0 && nzchar(redundant)) {
     redundant <- paste0("^", redundant)
     res <- res[!grepl(redundant, res)]
   }

--- a/tests/testthat/test-register.R
+++ b/tests/testthat/test-register.R
@@ -219,7 +219,7 @@ describe("generate_cpp_functions", {
       args = list(tibble::tibble(type = character(), name = character()))
     )
 
-    expect_equal(generate_cpp_functions(funs), character())
+    expect_equal(generate_cpp_functions(funs), "")
   })
 
   it("returns the wrapped function for a single void function with no arguments", {
@@ -388,7 +388,7 @@ describe("generate_r_functions", {
       args = list()
     )
 
-    expect_equal(generate_r_functions(funs), character())
+    expect_equal(generate_r_functions(funs), "")
   })
 
   it("returns the wrapped function for a single void function with no arguments", {

--- a/tests/testthat/test-register.R
+++ b/tests/testthat/test-register.R
@@ -208,6 +208,8 @@ describe("get_registered_functions", {
 
 describe("generate_cpp_functions", {
   it("returns the empty string if there are no functions", {
+    skip_if_not_installed("glue", "1.6.2.9000")
+
     funs <- tibble::tibble(
       file = character(),
       line = integer(),
@@ -377,6 +379,8 @@ extern \"C\" SEXP _cpp11_bar(SEXP baz) {
 
 describe("generate_r_functions", {
   it("returns the empty string if there are no functions", {
+    skip_if_not_installed("glue", "1.6.2.9000")
+
     funs <- tibble::tibble(
       file = character(),
       line = integer(),


### PR DESCRIPTION
In the next version of glue, `glue::glue_collapse()` will never return `character()` but instead will return `""` for empty inputs. For more detail see https://github.com/tidyverse/glue/pull/295.

This makes the necessary change inside cpp11 and places 2 temporary skips in the tests so cpp11 can be released before glue. Interestingly, this actually makes the tests match their existing descriptions.

I won't release glue for at least two weeks (so: March 31) and it will likely be later.