### PR TITLE
Remove `cpp11_should_unwind_protect` altogether

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # cpp11 (development version)
 
+* TODO (something about both the performance optimization being removed, and
+  the danger of using nested unwind_protect() calls from within the same .Call
+  entry point)
+
 # cpp11 0.4.5
 
 * On 2023-07-20, cpp11 was temporarily rolled back to 0.4.3 manually by CRAN due

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,11 @@
 # cpp11 (development version)
 
-* TODO (something about both the performance optimization being removed, and
-  the danger of using nested unwind_protect() calls from within the same .Call
-  entry point)
+* Nested calls to `cpp11::unwind_protect()` are no longer supported or
+  encouraged. Previously, this was something that could be done for performance
+  improvements, but ultimately this feature has proven to cause more problems
+  than it is worth and is very hard to use safely. For more information, see the
+  new `vignette("FAQ")` section titled "Should I call `cpp11::unwind_protect()`
+  manually?" (#327).
 
 # cpp11 0.4.5
 

--- a/cpp11test/R/cpp11.R
+++ b/cpp11test/R/cpp11.R
@@ -223,3 +223,11 @@ rcpp_sum_dbl_accumulate_ <- function(x_sxp) {
 rcpp_grow_ <- function(n_sxp) {
   .Call(`_cpp11test_rcpp_grow_`, n_sxp)
 }
+
+test_destruction_inner <- function() {
+  invisible(.Call(`_cpp11test_test_destruction_inner`))
+}
+
+test_destruction_outer <- function() {
+  invisible(.Call(`_cpp11test_test_destruction_outer`))
+}

--- a/cpp11test/src/cpp11.cpp
+++ b/cpp11test/src/cpp11.cpp
@@ -422,10 +422,26 @@ extern "C" SEXP _cpp11test_rcpp_grow_(SEXP n_sxp) {
     return cpp11::as_sexp(rcpp_grow_(cpp11::as_cpp<cpp11::decay_t<SEXP>>(n_sxp)));
   END_CPP11
 }
+// test-protect-nested.cpp
+void test_destruction_inner();
+extern "C" SEXP _cpp11test_test_destruction_inner() {
+  BEGIN_CPP11
+    test_destruction_inner();
+    return R_NilValue;
+  END_CPP11
+}
+// test-protect-nested.cpp
+void test_destruction_outer();
+extern "C" SEXP _cpp11test_test_destruction_outer() {
+  BEGIN_CPP11
+    test_destruction_outer();
+    return R_NilValue;
+  END_CPP11
+}
 
 extern "C" {
 /* .Call calls */
-extern SEXP run_testthat_tests(SEXP);
+extern SEXP run_testthat_tests(void *);
 
 static const R_CallMethodDef CallEntries[] = {
     {"_cpp11test_col_sums",                 (DL_FUNC) &_cpp11test_col_sums,                 1},
@@ -483,6 +499,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_cpp11test_sum_int_for2_",            (DL_FUNC) &_cpp11test_sum_int_for2_,            1},
     {"_cpp11test_sum_int_for_",             (DL_FUNC) &_cpp11test_sum_int_for_,             1},
     {"_cpp11test_sum_int_foreach_",         (DL_FUNC) &_cpp11test_sum_int_foreach_,         1},
+    {"_cpp11test_test_destruction_inner",   (DL_FUNC) &_cpp11test_test_destruction_inner,   0},
+    {"_cpp11test_test_destruction_outer",   (DL_FUNC) &_cpp11test_test_destruction_outer,   0},
     {"_cpp11test_upper_bound",              (DL_FUNC) &_cpp11test_upper_bound,              2},
     {"run_testthat_tests",                  (DL_FUNC) &run_testthat_tests,                  1},
     {NULL, NULL, 0}

--- a/cpp11test/src/test-protect-nested.cpp
+++ b/cpp11test/src/test-protect-nested.cpp
@@ -1,0 +1,81 @@
+#include "cpp11/function.hpp"
+#include "cpp11/protect.hpp"
+#include "testthat.h"
+
+#ifdef HAS_UNWIND_PROTECT
+
+/*
+ * See https://github.com/r-lib/cpp11/pull/327 for full details.
+ *
+ * - `cpp11::package("cpp11test")["test_destruction_outer"]` uses
+ *   `unwind_protect()` to call R level `test_destruction_outer()` but no entry
+ *   macros are set up. Instead we are going to catch exceptions that get here
+ *   with `expect_error_as()`.
+ *
+ *   - Call R level `test_destruction_outer()` to set up `BEGIN_CPP11` /
+ *     `END_CPP11` entry macros.
+ *
+ *   - C++ `test_destruction_outer()` goes through `unwind_protect()` to call
+ *     the R level `test_destruction_inner()`.
+ *
+ *     - R level `test_destruction_inner()` sets up its own `BEGIN_CPP11` /
+ *       `END_CPP11` entry macros.
+ *
+ *     - C++ `test_destruction_inner()` goes through `unwind_protect()` to call
+ *       `Rf_error()` (i.e., we are nested within `unwind_protect()`s!).
+ *
+ *     - `longjmp()` is caught from inner `unwind_protect()`, and an exception
+ *       is thrown which is caught by the inner entry macros, allowing us to run
+ *       the destructor of `x`, then we let R continue the unwind process.
+ *
+ *   - This `longjmp()`s again and is caught by the outer `unwind_protect()`, an
+ *     exception is thrown which is caught by the outer entry macros, and we let
+ *     R continue the unwind process one more time.
+ *
+ * - This `longjmp()` is caught by `cpp11::package()`'s `unwind_protect()`,
+ *   an exception is thrown, and that is caught by `expect_error_as()`.
+ */
+
+// Global variable to detect if the destructor has been run or not
+static bool destructed = false;
+
+class HasDestructor {
+ public:
+  ~HasDestructor();
+};
+
+HasDestructor::~HasDestructor() {
+  // Destructor has run!
+  destructed = true;
+}
+
+[[cpp11::register]] void test_destruction_inner() {
+  // Expect that `x`'s destructor gets to run on the way out
+  HasDestructor x{};
+  cpp11::stop("oh no!");
+}
+
+[[cpp11::register]] void test_destruction_outer() {
+  const auto test_destruction_inner =
+      cpp11::package("cpp11test")["test_destruction_inner"];
+  test_destruction_inner();
+}
+
+context("unwind_protect-nested-C++") {
+  test_that(
+      "nested `unwind_protect()` (with entry macros set up) will run destructors"
+      "(#327)") {
+    const auto fn = [&] {
+      const auto test_destruction_outer =
+          cpp11::package("cpp11test")["test_destruction_outer"];
+      test_destruction_outer();
+    };
+
+    expect_error_as(fn(), cpp11::unwind_exception);
+    expect_true(destructed);
+
+    destructed = false;
+  }
+}
+
+#endif

--- a/vignettes/FAQ.Rmd
+++ b/vignettes/FAQ.Rmd
@@ -334,7 +334,7 @@ test_destructor_bad()
 #> Error: oh no!
 ```
 
-In general, the only code that can be called within `unwind_protect()` is "pure" C code. If you mix complex C++ objects with R's C API within `unwind_protect()`, then any R errors will result in a jump that prevents your destructors from running.
+In general, the only code that can be called within `unwind_protect()` is "pure" C code or C++ code that only uses POD (plain-old-data) types and no exceptions. If you mix complex C++ objects with R's C API within `unwind_protect()`, then any R errors will result in a jump that prevents your destructors from running.
 
 ##### Nested `unwind_protect()`
 
@@ -359,7 +359,7 @@ If you were to run `test_nested()` from R, it would likely crash or hang your R 
 - The outer `unwind_protect()` is called. It uses the C function `R_UnwindProtect()` to call its lambda function.
 - The inner `unwind_protect()` is called. It again uses `R_UnwindProtect()`, this time to call `Rf_error()`.
 - `Rf_error()` performs a `longjmp()` which is caught by the inner `unwind_protect()` and promoted to an exception.
-- That exception is thrown, but because we are in the outer call to `R_UnwindProtect()` (a C function), we end up throwing that exception _across_ C stack frames. This is _undefined behavior_, which typically results in that exception not being caught anywhere, causing C++ (and ultimately R) to abort.
+- That exception is thrown, but because we are in the outer call to `R_UnwindProtect()` (a C function), we end up throwing that exception _across_ C stack frames. This is _undefined behavior_, which is known to have caused R to crash on certain platforms.
 
 You might think that you'd never do this, but the same scenario can also occur with a combination of 1 call to `unwind_protect()` combined with usage of the cpp11 API:
 
@@ -418,7 +418,7 @@ If you've read the above bullet and still feel like you need to call `unwind_pro
 - You shouldn't use any parts of the cpp11 API that may call `unwind_protect()`.
 - You must be very careful not to call `unwind_protect()` in a nested manner.
 
-In other words, if you only use plain-old-data types and only use R's C API within the `unwind_protect()`, then you can use it.
+In other words, if you only use plain-old-data types, are careful to never throw exceptions, and only use R's C API, then you can use `unwind_protect()`.
 
 One place you may want to do this is when working with long character vectors. Unfortunately, due to the way cpp11 must protect the individual CHARSXP objects that make up a character vector, it can currently be quite slow to use the cpp11 API for this. Consider this example of extracting out individual elements with `x[i]` vs using the native R API:
 

--- a/vignettes/FAQ.Rmd
+++ b/vignettes/FAQ.Rmd
@@ -3,8 +3,8 @@ title: "FAQ"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{FAQ}
-  %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
+  %\VignetteEngine{knitr::rmarkdown}
 ---
 
 ```{r, include = FALSE}
@@ -283,3 +283,181 @@ add_one(x)
 .Internal(inspect(x))
 x
 ```
+
+#### 15. Should I call `cpp11::unwind_protect()` manually?
+
+`cpp11::unwind_protect()` is cpp11's way of safely calling R's C API. In short, it allows you to run a function that might throw an R error, catch the `longjmp()` of that error, promote it to an exception that is thrown and caught by a try/catch that cpp11 sets up for you at `.Call()` time (which allows destructors to run), and finally tells R to continue unwinding the stack now that the C++ objects have had a chance to destruct as needed.
+
+Since `cpp11::unwind_protect()` takes an arbitrary function, you may be wondering if you should use it for your own custom needs. In general, we advise against this because this is an extremely advanced feature that is prone to subtle and hard to debug issues.
+
+##### Destructors
+
+The following setup for `test_destructor_ok()` with a manual call to `unwind_protect()` would work:
+
+```{cpp11}
+#include <cpp11.hpp>
+
+class A {
+ public:
+  ~A();
+};
+
+A::~A() {
+  Rprintf("hi from the destructor!");
+}
+
+[[cpp11::register]]
+void test_destructor_ok() {
+  A a{};
+  cpp11::unwind_protect([&] {
+    Rf_error("oh no!");  
+  });
+}
+
+[[cpp11::register]]
+void test_destructor_bad() {
+  cpp11::unwind_protect([&] {
+    A a{};
+    Rf_error("oh no!");  
+  });
+}
+```
+
+```{r, error=TRUE}
+test_destructor_ok()
+```
+
+But if you happen to move `a` into the `unwind_protect()`, then it won't be destructed, and you'll end up with a memory leak at best, and a much more sinister issue if your destructor is important:
+
+```{r, eval=FALSE}
+test_destructor_bad()
+#> Error: oh no!
+```
+
+In general, the only code that can be called within `unwind_protect()` is "pure" C code. If you mix complex C++ objects with R's C API within `unwind_protect()`, then any R errors will result in a jump that prevents your destructors from running.
+
+##### Nested `unwind_protect()`
+
+Another issue that can arise has to do with _nested_ calls to `unwind_protect()`. It is very hard (if not impossible) to end up with invalidly nested `unwind_protect()` calls when using the typical cpp11 API, but you can manually create a scenario like the following:
+
+```{cpp11}
+#include <cpp11.hpp>
+
+[[cpp11::register]]
+void test_nested() {
+  cpp11::unwind_protect([&] {
+    cpp11::unwind_protect([&] {
+      Rf_error("oh no!");  
+    });
+  });
+}
+```
+
+If you were to run `test_nested()` from R, it would likely crash or hang your R session due to the following chain of events:
+
+- `test_nested()` sets up a try/catch to catch unwind exceptions
+- The outer `unwind_protect()` is called. It uses the C function `R_UnwindProtect()` to call its lambda function.
+- The inner `unwind_protect()` is called. It again uses `R_UnwindProtect()`, this time to call `Rf_error()`.
+- `Rf_error()` performs a `longjmp()` which is caught by the inner `unwind_protect()` and promoted to an exception.
+- That exception is thrown, but because we are in the outer call to `R_UnwindProtect()` (a C function), we end up throwing that exception _across_ C stack frames. This is _undefined behavior_, which typically results in that exception not being caught anywhere, causing C++ (and ultimately R) to abort.
+
+You might think that you'd never do this, but the same scenario can also occur with a combination of 1 call to `unwind_protect()` combined with usage of the cpp11 API:
+
+```{cpp11}
+#include <cpp11.hpp>
+
+[[cpp11::register]]
+void test_hidden_nested() {
+  cpp11::unwind_protect([&] {
+    cpp11::stop("oh no!");
+  });
+}
+```
+
+Because `cpp11::stop()` (and most of the cpp11 API) uses `unwind_protect()` internally, we've indirectly ended up in a nested `unwind_protect()` scenario again.
+
+In general, if you must use `unwind_protect()` then you must be very careful not to use any of the cpp11 API inside of the `unwind_protect()` call.
+
+It is worth pointing out that calling out to an R function from cpp11 which then calls back into cpp11 is still safe, i.e. if the registered version of the imaginary `test_outer()` function below was called from R, then that would work:
+
+```{cpp11, eval = FALSE}
+#include <cpp11.hpp>
+
+[[cpp11::register]]
+void test_inner() {
+  cpp11::stop("oh no!")
+}
+
+[[cpp11::register]]
+void test_outer() {
+  auto fn = cpp11::package("mypackage")["test_inner"]
+  fn();
+}
+```
+
+This might seem unsafe because `cpp11::package()` uses `unwind_protect()` to call the R function for `test_inner()`, which then goes back into C++ to call `cpp11::stop()`, which itself uses `unwind_protect()`, so it seems like we are in a nested scenario, but this scenario does actually work. It makes more sense if we analyze it one step at a time:
+
+- Call the R function for `test_outer()`
+- A try/catch is set up to catch unwind exceptions
+- The C++ function for `test_outer()` is called
+- `cpp11::package()` uses `unwind_protect()` to call the R function for `test_inner()`
+- Call the R function for `test_inner()`
+- A try/catch is set up to catch unwind exceptions (_this is the key!_)
+- The C++ function for `test_inner()` is called
+- `cpp11::stop("oh no!")` is called, which uses `unwind_protect()` to call `Rf_error()`, causing a `longjmp()`, which is caught by that `unwind_protect()` and promoted to an exception.
+- That exception is thrown, but this time it is caught by the try/catch set up by `test_inner()` as we entered it from the R side. This prevents that exception from crossing the C++ -> C boundary.
+- The try/catch calls `R_ContinueUnwind()`, which `longjmp()`s again, and now the `unwind_protect()` set up by `cpp11::package()` catches that, and promotes it to an exception.
+- That exception is thrown and caught by the try/catch set up by `test_outer()`.
+- The try/catch calls `R_ContinueUnwind()`, which `longjmp()`s again, and at this point we can safely let the `longjmp()` proceed to force an R error.
+
+#### 16. Ok but I really want to call `cpp11::unwind_protect()` manually
+
+If you've read the above bullet and still feel like you need to call `unwind_protect()`, then you should keep in mind the following when writing the function to unwind-protect:
+
+- You shouldn't create any C++ objects that have destructors.
+- You shouldn't use any parts of the cpp11 API that may call `unwind_protect()`.
+- You must be very careful not to call `unwind_protect()` in a nested manner.
+
+In other words, if you only use plain-old-data types and only use R's C API within the `unwind_protect()`, then you can use it.
+
+One place you may want to do this is when working with long character vectors. Unfortunately, due to the way cpp11 must protect the individual CHARSXP objects that make up a character vector, it can currently be quite slow to use the cpp11 API for this. Consider this example of extracting out individual elements with `x[i]` vs using the native R API:
+
+```{cpp11}
+#include <cpp11.hpp>
+
+[[cpp11::register]]
+cpp11::sexp test_extract_cpp11(cpp11::strings x) {
+  const R_xlen_t size = x.size();
+
+  for (R_xlen_t i = 0; i < size; ++i) {
+    (void) x[i];
+  }
+  
+  return R_NilValue;
+}
+
+[[cpp11::register]]
+cpp11::sexp test_extract_r_api(cpp11::strings x) {
+  const R_xlen_t size = x.size();
+  const SEXP data{x};
+
+  cpp11::unwind_protect([&] {
+    for (R_xlen_t i = 0; i < size; ++i) {
+      (void) STRING_ELT(data, i);
+    }
+  });
+  
+  return R_NilValue;
+}
+```
+```{r}
+set.seed(123)
+x <- sample(letters, 1e6, replace = TRUE)
+
+bench::mark(
+  test_extract_cpp11(x), 
+  test_extract_r_api(x)
+)
+```
+
+We plan to improve on this in the future, but for now this is one of the only places where we feel it is reasonable to call `unwind_protect()` manually.

--- a/vignettes/internals.Rmd
+++ b/vignettes/internals.Rmd
@@ -31,22 +31,21 @@ You can load the package in an interactive R session
 devtools::load_all()
 ```
 
-Or run the tests with
+Or run the cpp11 tests with
 
 ```r
 devtools::test()
 ```
 
-`test()` will also re-compile the package if needed, so you do not always have to run `load_all()`.
+There are more extensive tests in the `cpp11test` directory. Generally when developing the C++ headers I run R with its working directory in the `cpp11test` directory and use `devtools::test()` to run the cpp11tests.
 
-If you change the cpp11 headers you will need to clean and recompile the cpp11test package
+If you change the cpp11 headers you will need to install the new version of cpp11 and then clean and recompile the cpp11test package:
 
 ```r
+# Assuming your working directory is `cpp11test/`
 devtools::clean_dll()
 devtools::load_all()
 ```
-
-Generally when developing the C++ headers I run R with its working directory in the `cpp11test` directory and use `devtools::test()` to run the cpp11tests.
 
 To calculate code coverage of the cpp11 package run the following from the `cpp11` root directory.
 
@@ -63,8 +62,6 @@ You can run `make format` to re-format all code in the project. If your system d
 You may need to link the newly installed version 10. To do so, run `brew unlink clang-format` followed by `brew link clang-format@10`.
 
 Alternatively many IDEs support automatically running `clang-format` every time files are written.
-
-
 
 ## Code organization
 


### PR DESCRIPTION
Closes #325 
Closes #326 

- [x] Update documentation to talk about dangers of nested unwind protection
- [x] Update documentation to talk about dangers of using C++ code that calls destructors from within a manual `unwind_protect()` call (since the destructors won't run if a longjmp occurs)
- [x] Update documentation to talk about performance of cpp11 character vectors in a loop, and how to use `unwind_protect()` manually to avoid the performance hit
- [x] Update NEWS bullet
- [x] 2nd order revdep checking (these came back clean)

Note that this makes the example from https://github.com/r-lib/cpp11/issues/298 very slow again, because nested `unwind_protect()` is no longer "optimized". This is an example where character vector manipulation may be better with a manual `unwind_protect()` + R C API usage