### PR TITLE
Ensure format strings pass check in R-devel/Windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # cpp11 (development version)
 
+* Internal changes requested by CRAN to fix invalid format string tokens
+  (@paleolimbot, #345).
+
 # cpp11 0.4.6
 
 * R >=3.5.0 is now required to use cpp11. This is in line with (and even goes

--- a/inst/include/cpp11/protect.hpp
+++ b/inst/include/cpp11/protect.hpp
@@ -279,7 +279,9 @@ static struct {
   void print() {
     static SEXP list = get_preserve_list();
     for (SEXP cell = list; cell != R_NilValue; cell = CDR(cell)) {
-      REprintf("%x CAR: %x CDR: %x TAG: %x\n", cell, CAR(cell), CDR(cell), TAG(cell));
+      REprintf("%p CAR: %p CDR: %p TAG: %p\n", reinterpret_cast<void*>(cell),
+               reinterpret_cast<void*>(CAR(cell)), reinterpret_cast<void*>(CDR(cell)),
+               reinterpret_cast<void*>(TAG(cell)));
     }
     REprintf("---\n");
   }

--- a/inst/include/cpp11/sexp.hpp
+++ b/inst/include/cpp11/sexp.hpp
@@ -20,14 +20,15 @@ class sexp {
   sexp() = default;
 
   sexp(SEXP data) : data_(data), preserve_token_(preserved.insert(data_)) {
-    // REprintf("created %x %x : %i\n", data_, preserve_token_, protect_head_size());
+    // REprintf("created %p %p\n", reinterpret_cast<void*>(data_),
+    //          reinterpret_cast<void*>(preserve_token_));
   }
 
   sexp(const sexp& rhs) {
     data_ = rhs.data_;
     preserve_token_ = preserved.insert(data_);
-    // REprintf("copied %x new protect %x : %i\n", rhs.data_, preserve_token_,
-    // protect_head_size());
+    // REprintf("copied %p new protect %p\n", reinterpret_cast<void*>(rhs.data_),
+    //          reinterpret_cast<void*>(preserve_token_));
   }
 
   sexp(sexp&& rhs) {
@@ -37,7 +38,7 @@ class sexp {
     rhs.data_ = R_NilValue;
     rhs.preserve_token_ = R_NilValue;
 
-    // REprintf("moved %x : %i\n", rhs.data_, protect_head_size());
+    // REprintf("moved %p\n", reinterpret_cast<void*>(rhs.data_));
   }
 
   sexp& operator=(const sexp& rhs) {
@@ -45,7 +46,7 @@ class sexp {
 
     data_ = rhs.data_;
     preserve_token_ = preserved.insert(data_);
-    // REprintf("assigned %x : %i\n", rhs.data_, protect_head_size());
+    // REprintf("assigned %p\n", reinterpret_cast<void*>(rhs.data_));
     return *this;
   }
 


### PR DESCRIPTION
Not sure exactly why this issue popped up on CI ( https://github.com/apache/arrow/pull/38894#issuecomment-1828488227 ), but it seems that at least one format string has `%x` (which expects an `int`) where I think the intention was to print memory addresses (i.e., `%p`). Our CI issue is probably because we're being a tad to aggressive about converting errors to warnings, but it seemed like an easy fix while I was taking a look!