### PR TITLE
Fix errors resulting from `-Wconversion -Wno-sign-conversion`

### DIFF
--- a/inst/include/cpp11/as.hpp
+++ b/inst/include/cpp11/as.hpp
@@ -92,22 +92,21 @@ template <typename T>
 enable_if_integral<T, T> as_cpp(SEXP from) {
   if (Rf_isInteger(from)) {
     if (Rf_xlength(from) == 1) {
-      return INTEGER_ELT(from, 0);
+      return static_cast<T>(INTEGER_ELT(from, 0));
     }
   } else if (Rf_isReal(from)) {
     if (Rf_xlength(from) == 1) {
-      if (ISNA(REAL_ELT(from, 0))) {
-        return NA_INTEGER;
-      }
       double value = REAL_ELT(from, 0);
-      if (is_convertible_without_loss_to_integer(value)) {
-        return value;
+      if (ISNA(value) && sizeof(T) >= sizeof(int)) {
+        return static_cast<T>(NA_INTEGER);
+      } else if (!ISNA(value) && is_convertible_without_loss_to_integer(value)) {
+        return static_cast<T>(value);
       }
     }
   } else if (Rf_isLogical(from)) {
     if (Rf_xlength(from) == 1) {
-      if (LOGICAL_ELT(from, 0) == NA_LOGICAL) {
-        return NA_INTEGER;
+      if (LOGICAL_ELT(from, 0) == NA_LOGICAL && sizeof(T) >= sizeof(int)) {
+        return static_cast<T>(NA_INTEGER);
       }
     }
   }

--- a/inst/include/cpp11/data_frame.hpp
+++ b/inst/include/cpp11/data_frame.hpp
@@ -36,7 +36,7 @@ class data_frame : public list {
     return R_NilValue;
   }
 
-  static int calc_nrow(SEXP x) {
+  static R_xlen_t calc_nrow(SEXP x) {
     auto nms = get_attrib0(x, R_RowNamesSymbol);
     bool has_short_rownames =
         (Rf_isInteger(nms) && Rf_xlength(nms) == 2 && INTEGER(nms)[0] == NA_INTEGER);

--- a/inst/include/cpp11/r_string.hpp
+++ b/inst/include/cpp11/r_string.hpp
@@ -17,7 +17,8 @@ class r_string {
   r_string(SEXP data) : data_(data) {}
   r_string(const char* data) : data_(safe[Rf_mkCharCE](data, CE_UTF8)) {}
   r_string(const std::string& data)
-      : data_(safe[Rf_mkCharLenCE](data.c_str(), static_cast<int>(data.size()), CE_UTF8)) {}
+      : data_(
+            safe[Rf_mkCharLenCE](data.c_str(), static_cast<int>(data.size()), CE_UTF8)) {}
 
   operator SEXP() const { return data_; }
   operator sexp() const { return data_; }

--- a/inst/include/cpp11/r_string.hpp
+++ b/inst/include/cpp11/r_string.hpp
@@ -17,7 +17,7 @@ class r_string {
   r_string(SEXP data) : data_(data) {}
   r_string(const char* data) : data_(safe[Rf_mkCharCE](data, CE_UTF8)) {}
   r_string(const std::string& data)
-      : data_(safe[Rf_mkCharLenCE](data.c_str(), data.size(), CE_UTF8)) {}
+      : data_(safe[Rf_mkCharLenCE](data.c_str(), static_cast<int>(data.size()), CE_UTF8)) {}
 
   operator SEXP() const { return data_; }
   operator sexp() const { return data_; }

--- a/inst/include/cpp11/sexp.hpp
+++ b/inst/include/cpp11/sexp.hpp
@@ -76,7 +76,7 @@ class sexp {
 
   operator SEXP() const { return data_; }
   operator double() const { return REAL_ELT(data_, 0); }
-  operator size_t() const { return REAL_ELT(data_, 0); }
+  operator size_t() const { return static_cast<size_t>(REAL_ELT(data_, 0)); }
   operator bool() const { return LOGICAL_ELT(data_, 0); }
   SEXP data() const { return data_; }
 };


### PR DESCRIPTION
The M1 runner apparently runs checks with `-Wconversion -Wno-sign-conversion -Werror`, which has caused the arrow package to have a very long list of compiler warnings/build failures on the package check page ( https://www.stats.ox.ac.uk/pub/bdr/M1mac/arrow.log ). Most of these are in the arrow package (fixed by https://github.com/apache/arrow/pull/39250 ), but a few are in the cpp11 headers.

The biggest change is for `as_cpp<>()`, templates for which we instantiate in arrow for `int64_t`, and `uint8_t`, both of which interact poorly with various pieces of that logic. I'm happy to update this and add some tests but I wanted to check first to see if there's consensus on what should actually happen. A few cases that were exposed by these warnings are:

```cpp
as_cpp<int64_t>(NA_INTEGER); // static_cast<int64_t>(NA_INTEGER)?
as_cpp<int8_t>(NA_REAL); // error?
as_cpp<int8_t>(NA_INTEGER); // error?
as_cpp<int>(static_cast<double>(INT_MAX) + 1); // error?
```