### PR TITLE
Simplify preserve list approach

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # cpp11 (development version)
 
+* The approach for the protection list managed by cpp11 has been tweaked
+  slightly. In 0.4.6, we changed to an approach that creates one protection list
+  per compilation unit, but we now believe we've found an approach that is
+  guaranteed by the C++ standard to create one protection list per package,
+  which makes slightly more sense and still has all the benefits of the reduced
+  maintanence burden mentioned in the 0.4.6 news bullet (#364).
+
+  A side effect of this new approach is that the `preserved` object exposed
+  through `protect.hpp` no longer exists. We don't believe that anyone was using
+  this.
+
 * Dropped support for gcc 4.8, mainly an issue for extremely old CentOS 7
   systems which used that as their default compiler. As of June 2024, CentOS 7
   is past its Vendor end of support date and therefore also out of scope for

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,8 @@
 
   A side effect of this new approach is that the `preserved` object exposed
   through `protect.hpp` no longer exists. We don't believe that anyone was using
-  this.
+  this. This also means you should no longer see "unused variable" warnings
+  about `preserved` (#249).
 
 * Dropped support for gcc 4.8, mainly an issue for extremely old CentOS 7
   systems which used that as their default compiler. As of June 2024, CentOS 7

--- a/cpp11test/src/protect.cpp
+++ b/cpp11test/src/protect.cpp
@@ -18,8 +18,8 @@
 
 [[cpp11::register]] void protect_one_cpp11_(SEXP x, int n) {
   for (R_xlen_t i = 0; i < n; ++i) {
-    SEXP p = cpp11::detail::store_insert(x);
-    cpp11::detail::store_release(p);
+    SEXP p = cpp11::detail::store::insert(x);
+    cpp11::detail::store::release(p);
   }
 }
 
@@ -51,12 +51,12 @@
 [[cpp11::register]] void protect_many_cpp11_(int n) {
   std::vector<SEXP> res;
   for (R_xlen_t i = 0; i < n; ++i) {
-    res.push_back(cpp11::detail::store_insert(Rf_ScalarInteger(n)));
+    res.push_back(cpp11::detail::store::insert(Rf_ScalarInteger(n)));
   }
 
   for (R_xlen_t i = n - 1; i >= 0; --i) {
     SEXP x = res[i];
-    cpp11::detail::store_release(x);
+    cpp11::detail::store::release(x);
     res.pop_back();
   }
 }

--- a/cpp11test/src/protect.cpp
+++ b/cpp11test/src/protect.cpp
@@ -18,8 +18,8 @@
 
 [[cpp11::register]] void protect_one_cpp11_(SEXP x, int n) {
   for (R_xlen_t i = 0; i < n; ++i) {
-    SEXP p = cpp11::preserved.insert(x);
-    cpp11::preserved.release(p);
+    SEXP p = cpp11::detail::store_insert(x);
+    cpp11::detail::store_release(p);
   }
 }
 
@@ -32,18 +32,6 @@
 
 // The internal protections here are actually uneeded, but it is a useful way to benchmark
 // them
-//
-// clang-format off
-#ifdef __clang__
-# pragma clang diagnostic push
-# pragma clang diagnostic ignored "-Wunused-variable"
-#endif
-
-#ifdef __GNUC__
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wunused-variable"
-#endif
-// clang-format on
 
 [[cpp11::register]] void protect_many_(int n) {
 #ifdef CPP11_BENCH
@@ -63,12 +51,12 @@
 [[cpp11::register]] void protect_many_cpp11_(int n) {
   std::vector<SEXP> res;
   for (R_xlen_t i = 0; i < n; ++i) {
-    res.push_back(cpp11::preserved.insert(Rf_ScalarInteger(n)));
+    res.push_back(cpp11::detail::store_insert(Rf_ScalarInteger(n)));
   }
 
   for (R_xlen_t i = n - 1; i >= 0; --i) {
     SEXP x = res[i];
-    cpp11::preserved.release(x);
+    cpp11::detail::store_release(x);
     res.pop_back();
   }
 }

--- a/cpp11test/src/test-protect.cpp
+++ b/cpp11test/src/test-protect.cpp
@@ -1,16 +1,3 @@
-// Avoid unused variable warnings regarding `cpp11::preserved`
-// clang-format off
-#ifdef __clang__
-# pragma clang diagnostic push
-# pragma clang diagnostic ignored "-Wunused-variable"
-#endif
-
-#ifdef __GNUC__
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wunused-variable"
-#endif
-// clang-format on
-
 #define CPP11_USE_FMT
 #include "cpp11/protect.hpp"
 #include "testthat.h"

--- a/inst/include/cpp11/doubles.hpp
+++ b/inst/include/cpp11/doubles.hpp
@@ -84,7 +84,7 @@ template <>
 inline r_vector<double>::r_vector(std::initializer_list<named_arg> il)
     : cpp11::r_vector<double>(safe[Rf_allocVector](REALSXP, il.size())),
       capacity_(il.size()) {
-  protect_ = preserved.insert(data_);
+  protect_ = detail::store_insert(data_);
   int n_protected = 0;
 
   try {
@@ -100,7 +100,7 @@ inline r_vector<double>::r_vector(std::initializer_list<named_arg> il)
       UNPROTECT(n_protected);
     });
   } catch (const unwind_exception& e) {
-    preserved.release(protect_);
+    detail::store_release(protect_);
     UNPROTECT(n_protected);
     throw e;
   }
@@ -111,8 +111,8 @@ inline void r_vector<double>::reserve(R_xlen_t new_capacity) {
   data_ = data_ == R_NilValue ? safe[Rf_allocVector](REALSXP, new_capacity)
                               : safe[Rf_xlengthgets](data_, new_capacity);
   SEXP old_protect = protect_;
-  protect_ = preserved.insert(data_);
-  preserved.release(old_protect);
+  protect_ = detail::store_insert(data_);
+  detail::store_release(old_protect);
 
   data_p_ = REAL(data_);
   capacity_ = new_capacity;

--- a/inst/include/cpp11/doubles.hpp
+++ b/inst/include/cpp11/doubles.hpp
@@ -84,7 +84,7 @@ template <>
 inline r_vector<double>::r_vector(std::initializer_list<named_arg> il)
     : cpp11::r_vector<double>(safe[Rf_allocVector](REALSXP, il.size())),
       capacity_(il.size()) {
-  protect_ = detail::store_insert(data_);
+  protect_ = detail::store::insert(data_);
   int n_protected = 0;
 
   try {
@@ -100,7 +100,7 @@ inline r_vector<double>::r_vector(std::initializer_list<named_arg> il)
       UNPROTECT(n_protected);
     });
   } catch (const unwind_exception& e) {
-    detail::store_release(protect_);
+    detail::store::release(protect_);
     UNPROTECT(n_protected);
     throw e;
   }
@@ -111,8 +111,8 @@ inline void r_vector<double>::reserve(R_xlen_t new_capacity) {
   data_ = data_ == R_NilValue ? safe[Rf_allocVector](REALSXP, new_capacity)
                               : safe[Rf_xlengthgets](data_, new_capacity);
   SEXP old_protect = protect_;
-  protect_ = detail::store_insert(data_);
-  detail::store_release(old_protect);
+  protect_ = detail::store::insert(data_);
+  detail::store::release(old_protect);
 
   data_p_ = REAL(data_);
   capacity_ = new_capacity;

--- a/inst/include/cpp11/integers.hpp
+++ b/inst/include/cpp11/integers.hpp
@@ -9,7 +9,7 @@
 #include "cpp11/as.hpp"               // for as_sexp
 #include "cpp11/attribute_proxy.hpp"  // for attribute_proxy
 #include "cpp11/named_arg.hpp"        // for named_arg
-#include "cpp11/protect.hpp"          // for store_insert, store_release
+#include "cpp11/protect.hpp"          // for store
 #include "cpp11/r_vector.hpp"         // for r_vector, r_vector<>::proxy
 #include "cpp11/sexp.hpp"             // for sexp
 
@@ -87,10 +87,10 @@ inline void r_vector<int>::reserve(R_xlen_t new_capacity) {
   SEXP old_protect = protect_;
 
   // Protect the new data
-  protect_ = detail::store_insert(data_);
+  protect_ = detail::store::insert(data_);
 
   // Release the old protection;
-  detail::store_release(old_protect);
+  detail::store::release(old_protect);
 
   data_p_ = INTEGER(data_);
   capacity_ = new_capacity;
@@ -100,7 +100,7 @@ template <>
 inline r_vector<int>::r_vector(std::initializer_list<named_arg> il)
     : cpp11::r_vector<int>(safe[Rf_allocVector](INTSXP, il.size())),
       capacity_(il.size()) {
-  protect_ = detail::store_insert(data_);
+  protect_ = detail::store::insert(data_);
   int n_protected = 0;
 
   try {
@@ -116,7 +116,7 @@ inline r_vector<int>::r_vector(std::initializer_list<named_arg> il)
       UNPROTECT(n_protected);
     });
   } catch (const unwind_exception& e) {
-    detail::store_release(protect_);
+    detail::store::release(protect_);
     UNPROTECT(n_protected);
     throw e;
   }

--- a/inst/include/cpp11/integers.hpp
+++ b/inst/include/cpp11/integers.hpp
@@ -9,7 +9,7 @@
 #include "cpp11/as.hpp"               // for as_sexp
 #include "cpp11/attribute_proxy.hpp"  // for attribute_proxy
 #include "cpp11/named_arg.hpp"        // for named_arg
-#include "cpp11/protect.hpp"          // for preserved
+#include "cpp11/protect.hpp"          // for store_insert, store_release
 #include "cpp11/r_vector.hpp"         // for r_vector, r_vector<>::proxy
 #include "cpp11/sexp.hpp"             // for sexp
 
@@ -87,10 +87,10 @@ inline void r_vector<int>::reserve(R_xlen_t new_capacity) {
   SEXP old_protect = protect_;
 
   // Protect the new data
-  protect_ = preserved.insert(data_);
+  protect_ = detail::store_insert(data_);
 
   // Release the old protection;
-  preserved.release(old_protect);
+  detail::store_release(old_protect);
 
   data_p_ = INTEGER(data_);
   capacity_ = new_capacity;
@@ -100,7 +100,7 @@ template <>
 inline r_vector<int>::r_vector(std::initializer_list<named_arg> il)
     : cpp11::r_vector<int>(safe[Rf_allocVector](INTSXP, il.size())),
       capacity_(il.size()) {
-  protect_ = preserved.insert(data_);
+  protect_ = detail::store_insert(data_);
   int n_protected = 0;
 
   try {
@@ -116,7 +116,7 @@ inline r_vector<int>::r_vector(std::initializer_list<named_arg> il)
       UNPROTECT(n_protected);
     });
   } catch (const unwind_exception& e) {
-    preserved.release(protect_);
+    detail::store_release(protect_);
     UNPROTECT(n_protected);
     throw e;
   }

--- a/inst/include/cpp11/list.hpp
+++ b/inst/include/cpp11/list.hpp
@@ -5,7 +5,7 @@
 #include "cpp11/R.hpp"                // for SEXP, SEXPREC, SET_VECTOR_ELT
 #include "cpp11/attribute_proxy.hpp"  // for attribute_proxy
 #include "cpp11/named_arg.hpp"        // for named_arg
-#include "cpp11/protect.hpp"          // for store_insert, store_release
+#include "cpp11/protect.hpp"          // for store
 #include "cpp11/r_string.hpp"         // for r_string
 #include "cpp11/r_vector.hpp"         // for r_vector, r_vector<>::proxy
 #include "cpp11/sexp.hpp"             // for sexp
@@ -78,7 +78,7 @@ template <>
 inline r_vector<SEXP>::r_vector(std::initializer_list<SEXP> il)
     : cpp11::r_vector<SEXP>(safe[Rf_allocVector](VECSXP, il.size())),
       capacity_(il.size()) {
-  protect_ = detail::store_insert(data_);
+  protect_ = detail::store::insert(data_);
   auto it = il.begin();
   for (R_xlen_t i = 0; i < capacity_; ++i, ++it) {
     SET_VECTOR_ELT(data_, i, *it);
@@ -89,7 +89,7 @@ template <>
 inline r_vector<SEXP>::r_vector(std::initializer_list<named_arg> il)
     : cpp11::r_vector<SEXP>(safe[Rf_allocVector](VECSXP, il.size())),
       capacity_(il.size()) {
-  protect_ = detail::store_insert(data_);
+  protect_ = detail::store::insert(data_);
   int n_protected = 0;
 
   try {
@@ -105,7 +105,7 @@ inline r_vector<SEXP>::r_vector(std::initializer_list<named_arg> il)
       UNPROTECT(n_protected);
     });
   } catch (const unwind_exception& e) {
-    detail::store_release(protect_);
+    detail::store::release(protect_);
     UNPROTECT(n_protected);
     throw e;
   }
@@ -117,8 +117,8 @@ inline void r_vector<SEXP>::reserve(R_xlen_t new_capacity) {
                               : safe[Rf_xlengthgets](data_, new_capacity);
 
   SEXP old_protect = protect_;
-  protect_ = detail::store_insert(data_);
-  detail::store_release(old_protect);
+  protect_ = detail::store::insert(data_);
+  detail::store::release(old_protect);
 
   capacity_ = new_capacity;
 }

--- a/inst/include/cpp11/list.hpp
+++ b/inst/include/cpp11/list.hpp
@@ -5,7 +5,7 @@
 #include "cpp11/R.hpp"                // for SEXP, SEXPREC, SET_VECTOR_ELT
 #include "cpp11/attribute_proxy.hpp"  // for attribute_proxy
 #include "cpp11/named_arg.hpp"        // for named_arg
-#include "cpp11/protect.hpp"          // for preserved
+#include "cpp11/protect.hpp"          // for store_insert, store_release
 #include "cpp11/r_string.hpp"         // for r_string
 #include "cpp11/r_vector.hpp"         // for r_vector, r_vector<>::proxy
 #include "cpp11/sexp.hpp"             // for sexp
@@ -78,7 +78,7 @@ template <>
 inline r_vector<SEXP>::r_vector(std::initializer_list<SEXP> il)
     : cpp11::r_vector<SEXP>(safe[Rf_allocVector](VECSXP, il.size())),
       capacity_(il.size()) {
-  protect_ = preserved.insert(data_);
+  protect_ = detail::store_insert(data_);
   auto it = il.begin();
   for (R_xlen_t i = 0; i < capacity_; ++i, ++it) {
     SET_VECTOR_ELT(data_, i, *it);
@@ -89,7 +89,7 @@ template <>
 inline r_vector<SEXP>::r_vector(std::initializer_list<named_arg> il)
     : cpp11::r_vector<SEXP>(safe[Rf_allocVector](VECSXP, il.size())),
       capacity_(il.size()) {
-  protect_ = preserved.insert(data_);
+  protect_ = detail::store_insert(data_);
   int n_protected = 0;
 
   try {
@@ -105,7 +105,7 @@ inline r_vector<SEXP>::r_vector(std::initializer_list<named_arg> il)
       UNPROTECT(n_protected);
     });
   } catch (const unwind_exception& e) {
-    preserved.release(protect_);
+    detail::store_release(protect_);
     UNPROTECT(n_protected);
     throw e;
   }
@@ -117,8 +117,8 @@ inline void r_vector<SEXP>::reserve(R_xlen_t new_capacity) {
                               : safe[Rf_xlengthgets](data_, new_capacity);
 
   SEXP old_protect = protect_;
-  protect_ = preserved.insert(data_);
-  preserved.release(old_protect);
+  protect_ = detail::store_insert(data_);
+  detail::store_release(old_protect);
 
   capacity_ = new_capacity;
 }

--- a/inst/include/cpp11/logicals.hpp
+++ b/inst/include/cpp11/logicals.hpp
@@ -7,7 +7,7 @@
 #include "cpp11/R.hpp"                // for SEXP, SEXPREC, Rf_all...
 #include "cpp11/attribute_proxy.hpp"  // for attribute_proxy
 #include "cpp11/named_arg.hpp"        // for named_arg
-#include "cpp11/protect.hpp"          // for store_insert, store_release
+#include "cpp11/protect.hpp"          // for store
 #include "cpp11/r_bool.hpp"           // for r_bool
 #include "cpp11/r_vector.hpp"         // for r_vector, r_vector<>::proxy
 #include "cpp11/sexp.hpp"             // for sexp
@@ -80,7 +80,7 @@ inline bool operator==(const r_vector<r_bool>::proxy& lhs, r_bool rhs) {
 template <>
 inline r_vector<r_bool>::r_vector(std::initializer_list<r_bool> il)
     : cpp11::r_vector<r_bool>(Rf_allocVector(LGLSXP, il.size())), capacity_(il.size()) {
-  protect_ = detail::store_insert(data_);
+  protect_ = detail::store::insert(data_);
   auto it = il.begin();
   for (R_xlen_t i = 0; i < capacity_; ++i, ++it) {
     SET_LOGICAL_ELT(data_, i, *it);
@@ -91,7 +91,7 @@ template <>
 inline r_vector<r_bool>::r_vector(std::initializer_list<named_arg> il)
     : cpp11::r_vector<r_bool>(safe[Rf_allocVector](LGLSXP, il.size())),
       capacity_(il.size()) {
-  protect_ = detail::store_insert(data_);
+  protect_ = detail::store::insert(data_);
   int n_protected = 0;
 
   try {
@@ -107,7 +107,7 @@ inline r_vector<r_bool>::r_vector(std::initializer_list<named_arg> il)
       UNPROTECT(n_protected);
     });
   } catch (const unwind_exception& e) {
-    detail::store_release(protect_);
+    detail::store::release(protect_);
     UNPROTECT(n_protected);
     throw e;
   }
@@ -118,9 +118,9 @@ inline void r_vector<r_bool>::reserve(R_xlen_t new_capacity) {
   data_ = data_ == R_NilValue ? safe[Rf_allocVector](LGLSXP, new_capacity)
                               : safe[Rf_xlengthgets](data_, new_capacity);
   SEXP old_protect = protect_;
-  protect_ = detail::store_insert(data_);
+  protect_ = detail::store::insert(data_);
 
-  detail::store_release(old_protect);
+  detail::store::release(old_protect);
 
   data_p_ = LOGICAL(data_);
   capacity_ = new_capacity;

--- a/inst/include/cpp11/protect.hpp
+++ b/inst/include/cpp11/protect.hpp
@@ -245,84 +245,94 @@ void warning(const std::string& fmt, Args... args) {
 }
 #endif
 
-/// A doubly-linked list of preserved objects, allowing O(1) insertion/release of
-/// objects compared to O(N preserved) with R_PreserveObject.
-static struct {
-  SEXP insert(SEXP obj) {
-    if (obj == R_NilValue) {
-      return R_NilValue;
-    }
+namespace detail {
 
-    PROTECT(obj);
+// A doubly-linked list of preserved objects, allowing O(1) insertion/release of objects
+// compared to O(N preserved) with `R_PreserveObject()` and `R_ReleaseObject()`.
+//
+// We let R manage the memory of the list itself by calling `R_PreserveObject()` on it.
+//
+// cpp11 being a header only library makes creating a "global" preserve list a bit tricky.
+// The trick we use here is that static local variables in inline extern functions are
+// guaranteed by the standard to be unique across the whole program. Inline functions are
+// extern by default, but `static inline` functions are not, so do not change these
+// functions to `static`. If we did that, we would end up having one preserve list per
+// compilation unit instead. As it stands today, we are fairly confident that we have 1
+// preserve list per package, which seems to work nicely.
+// https://stackoverflow.com/questions/185624/what-happens-to-static-variables-in-inline-functions
+// https://stackoverflow.com/questions/51612866/global-variables-in-header-only-library
+// https://github.com/r-lib/cpp11/issues/330
+//
+// > A static local variable in an extern inline function always refers to the
+//   same object. 7.1.2/4 - C++98/C++14 (n3797)
 
-    static SEXP list = get_preserve_list();
+inline SEXP new_store() {
+  SEXP out = Rf_cons(R_NilValue, Rf_cons(R_NilValue, R_NilValue));
+  R_PreserveObject(out);
+  return out;
+}
 
-    // Get references to the head of the precious list and the next element
-    // after the head
-    SEXP head = list;
-    SEXP next = CDR(list);
+inline SEXP store() {
+  // Note the `static` local variable in the inline extern function here! Guarantees we
+  // have 1 unique preserve list across all compilation units in the package.
+  static SEXP out = new_store();
+  return out;
+}
 
-    // Add a new cell that points to the current head + next.
-    SEXP cell = PROTECT(Rf_cons(head, next));
-    SET_TAG(cell, obj);
-
-    // Update the head + next to point at the newly-created cell,
-    // effectively inserting that cell between the current head + next.
-    SETCDR(head, cell);
-    SETCAR(next, cell);
-
-    UNPROTECT(2);
-
-    return cell;
+inline SEXP store_insert(SEXP x) {
+  if (x == R_NilValue) {
+    return R_NilValue;
   }
 
-  void print() {
-    static SEXP list = get_preserve_list();
-    for (SEXP cell = list; cell != R_NilValue; cell = CDR(cell)) {
-      REprintf("%p CAR: %p CDR: %p TAG: %p\n", reinterpret_cast<void*>(cell),
-               reinterpret_cast<void*>(CAR(cell)), reinterpret_cast<void*>(CDR(cell)),
-               reinterpret_cast<void*>(TAG(cell)));
-    }
-    REprintf("---\n");
+  PROTECT(x);
+
+  SEXP list = store();
+
+  // Get references to the head of the preserve list and the next element
+  // after the head
+  SEXP head = list;
+  SEXP next = CDR(list);
+
+  // Add a new cell that points to the current head + next.
+  SEXP cell = PROTECT(Rf_cons(head, next));
+  SET_TAG(cell, x);
+
+  // Update the head + next to point at the newly-created cell,
+  // effectively inserting that cell between the current head + next.
+  SETCDR(head, cell);
+  SETCAR(next, cell);
+
+  UNPROTECT(2);
+
+  return cell;
+}
+
+inline void store_release(SEXP cell) {
+  if (cell == R_NilValue) {
+    return;
   }
 
-  void release(SEXP cell) {
-    if (cell == R_NilValue) {
-      return;
-    }
+  // Get a reference to the cells before and after the token.
+  SEXP lhs = CAR(cell);
+  SEXP rhs = CDR(cell);
 
-    // Get a reference to the cells before and after the token.
-    SEXP lhs = CAR(cell);
-    SEXP rhs = CDR(cell);
+  // Remove the cell from the preserve list -- effectively, we do this
+  // by updating the 'lhs' and 'rhs' references to point at each-other,
+  // effectively removing any references to the cell in the pairlist.
+  SETCDR(lhs, rhs);
+  SETCAR(rhs, lhs);
+}
 
-    // Remove the cell from the precious list -- effectively, we do this
-    // by updating the 'lhs' and 'rhs' references to point at each-other,
-    // effectively removing any references to the cell in the pairlist.
-    SETCDR(lhs, rhs);
-    SETCAR(rhs, lhs);
+inline void store_print() {
+  SEXP list = store();
+  for (SEXP cell = list; cell != R_NilValue; cell = CDR(cell)) {
+    REprintf("%p CAR: %p CDR: %p TAG: %p\n", reinterpret_cast<void*>(cell),
+             reinterpret_cast<void*>(CAR(cell)), reinterpret_cast<void*>(CDR(cell)),
+             reinterpret_cast<void*>(TAG(cell)));
   }
+  REprintf("---\n");
+}
 
- private:
-  // Each compilation unit purposefully gets its own preserve list.
-  // This avoids issues with sharing preserve list state across compilation units
-  // and across packages, which has historically caused many issues (#330).
-  static SEXP get_preserve_list() {
-    static SEXP out = init_preserve_list();
-    return out;
-  }
-
-  static SEXP init_preserve_list() {
-    // Initialize the list exactly once per compilation unit,
-    // and let R manage its memory
-    SEXP out = new_preserve_list();
-    R_PreserveObject(out);
-    return out;
-  }
-
-  static SEXP new_preserve_list() {
-    return Rf_cons(R_NilValue, Rf_cons(R_NilValue, R_NilValue));
-  }
-
-} preserved;
+}  // namespace detail
 
 }  // namespace cpp11

--- a/inst/include/cpp11/r_bool.hpp
+++ b/inst/include/cpp11/r_bool.hpp
@@ -7,7 +7,7 @@
 #include "R_ext/Boolean.h"    // for Rboolean
 #include "cpp11/R.hpp"        // for SEXP, SEXPREC, ...
 #include "cpp11/as.hpp"       // for as_sexp
-#include "cpp11/protect.hpp"  // for unwind_protect, preserved
+#include "cpp11/protect.hpp"  // for unwind_protect
 #include "cpp11/r_vector.hpp"
 #include "cpp11/sexp.hpp"  // for sexp
 

--- a/inst/include/cpp11/r_vector.hpp
+++ b/inst/include/cpp11/r_vector.hpp
@@ -15,7 +15,7 @@
 
 #include "cpp11/R.hpp"                // for R_xlen_t, SEXP, SEXPREC, Rf_xle...
 #include "cpp11/attribute_proxy.hpp"  // for attribute_proxy
-#include "cpp11/protect.hpp"          // for preserved
+#include "cpp11/protect.hpp"          // for store_insert, store_release
 #include "cpp11/r_string.hpp"         // for r_string
 #include "cpp11/sexp.hpp"             // for sexp
 
@@ -82,12 +82,12 @@ class r_vector {
     SEXP old_protect = protect_;
 
     data_ = rhs.data_;
-    protect_ = preserved.insert(data_);
+    protect_ = detail::store_insert(data_);
     is_altrep_ = rhs.is_altrep_;
     data_p_ = rhs.data_p_;
     length_ = rhs.length_;
 
-    preserved.release(old_protect);
+    detail::store_release(old_protect);
 
     return *this;
   };
@@ -96,12 +96,12 @@ class r_vector {
     SEXP old_protect = protect_;
 
     data_ = rhs.data_;
-    protect_ = preserved.insert(data_);
+    protect_ = detail::store_insert(data_);
     is_altrep_ = rhs.is_altrep_;
     data_p_ = rhs.data_p_;
     length_ = rhs.length_;
 
-    preserved.release(old_protect);
+    detail::store_release(old_protect);
   };
 
   r_vector(const writable::r_vector<T>& rhs) : r_vector(static_cast<SEXP>(rhs)) {}
@@ -189,7 +189,7 @@ class r_vector {
 
   const_iterator find(const r_string& name) const;
 
-  ~r_vector() { preserved.release(protect_); }
+  ~r_vector() { detail::store_release(protect_); }
 
  private:
   SEXP data_ = R_NilValue;
@@ -371,7 +371,7 @@ class r_vector : public cpp11::r_vector<T> {
 template <typename T>
 inline r_vector<T>::r_vector(const SEXP data)
     : data_(valid_type(data)),
-      protect_(preserved.insert(data)),
+      protect_(detail::store_insert(data)),
       is_altrep_(ALTREP(data)),
       data_p_(get_p(ALTREP(data), data)),
       length_(Rf_xlength(data)) {}
@@ -379,7 +379,7 @@ inline r_vector<T>::r_vector(const SEXP data)
 template <typename T>
 inline r_vector<T>::r_vector(const SEXP data, bool is_altrep)
     : data_(valid_type(data)),
-      protect_(preserved.insert(data)),
+      protect_(detail::store_insert(data)),
       is_altrep_(is_altrep),
       data_p_(get_p(is_altrep, data)),
       length_(Rf_xlength(data)) {}
@@ -661,23 +661,23 @@ inline typename r_vector<T>::iterator r_vector<T>::end() const {
 template <typename T>
 inline r_vector<T>::r_vector(const SEXP& data)
     : cpp11::r_vector<T>(safe[Rf_shallow_duplicate](data)),
-      protect_(preserved.insert(data_)),
+      protect_(detail::store_insert(data_)),
       capacity_(length_) {}
 
 template <typename T>
 inline r_vector<T>::r_vector(const SEXP& data, bool is_altrep)
     : cpp11::r_vector<T>(safe[Rf_shallow_duplicate](data), is_altrep),
-      protect_(preserved.insert(data_)),
+      protect_(detail::store_insert(data_)),
       capacity_(length_) {}
 
 template <typename T>
 inline r_vector<T>::r_vector(SEXP&& data)
-    : cpp11::r_vector<T>(data), protect_(preserved.insert(data_)), capacity_(length_) {}
+    : cpp11::r_vector<T>(data), protect_(detail::store_insert(data_)), capacity_(length_) {}
 
 template <typename T>
 inline r_vector<T>::r_vector(SEXP&& data, bool is_altrep)
     : cpp11::r_vector<T>(data, is_altrep),
-      protect_(preserved.insert(data_)),
+      protect_(detail::store_insert(data_)),
       capacity_(length_) {}
 
 template <typename T>
@@ -709,7 +709,7 @@ inline r_vector<T>::r_vector(const R_xlen_t size) : r_vector() {
 
 template <typename T>
 inline r_vector<T>::~r_vector() {
-  preserved.release(protect_);
+  detail::store_release(protect_);
 }
 
 #ifdef LONG_VECTOR_SUPPORT
@@ -792,7 +792,7 @@ inline typename r_vector<T>::iterator r_vector<T>::find(const r_string& name) co
 template <typename T>
 inline r_vector<T>::r_vector(const r_vector<T>& rhs)
     : cpp11::r_vector<T>(safe[Rf_shallow_duplicate](rhs)),
-      protect_(preserved.insert(data_)),
+      protect_(detail::store_insert(data_)),
       capacity_(rhs.capacity_) {}
 
 template <typename T>
@@ -805,7 +805,7 @@ inline r_vector<T>::r_vector(r_vector<T>&& rhs)
 template <typename T>
 inline r_vector<T>::r_vector(const cpp11::r_vector<T>& rhs)
     : cpp11::r_vector<T>(safe[Rf_shallow_duplicate](rhs)),
-      protect_(preserved.insert(data_)),
+      protect_(detail::store_insert(data_)),
       capacity_(rhs.length_) {}
 
 // We don't release the old object until the end in case we throw an exception
@@ -821,9 +821,9 @@ inline r_vector<T>& r_vector<T>::operator=(const r_vector<T>& rhs) {
   auto old_protect = protect_;
 
   data_ = safe[Rf_shallow_duplicate](rhs.data_);
-  protect_ = preserved.insert(data_);
+  protect_ = detail::store_insert(data_);
 
-  preserved.release(old_protect);
+  detail::store_release(old_protect);
 
   capacity_ = rhs.capacity_;
 
@@ -841,9 +841,9 @@ inline r_vector<T>& r_vector<T>::operator=(r_vector<T>&& rhs) {
   SEXP old_protect = protect_;
 
   data_ = rhs.data_;
-  protect_ = preserved.insert(data_);
+  protect_ = detail::store_insert(data_);
 
-  preserved.release(old_protect);
+  detail::store_release(old_protect);
 
   capacity_ = rhs.capacity_;
 

--- a/inst/include/cpp11/r_vector.hpp
+++ b/inst/include/cpp11/r_vector.hpp
@@ -15,7 +15,7 @@
 
 #include "cpp11/R.hpp"                // for R_xlen_t, SEXP, SEXPREC, Rf_xle...
 #include "cpp11/attribute_proxy.hpp"  // for attribute_proxy
-#include "cpp11/protect.hpp"          // for store_insert, store_release
+#include "cpp11/protect.hpp"          // for store
 #include "cpp11/r_string.hpp"         // for r_string
 #include "cpp11/sexp.hpp"             // for sexp
 
@@ -82,12 +82,12 @@ class r_vector {
     SEXP old_protect = protect_;
 
     data_ = rhs.data_;
-    protect_ = detail::store_insert(data_);
+    protect_ = detail::store::insert(data_);
     is_altrep_ = rhs.is_altrep_;
     data_p_ = rhs.data_p_;
     length_ = rhs.length_;
 
-    detail::store_release(old_protect);
+    detail::store::release(old_protect);
 
     return *this;
   };
@@ -96,12 +96,12 @@ class r_vector {
     SEXP old_protect = protect_;
 
     data_ = rhs.data_;
-    protect_ = detail::store_insert(data_);
+    protect_ = detail::store::insert(data_);
     is_altrep_ = rhs.is_altrep_;
     data_p_ = rhs.data_p_;
     length_ = rhs.length_;
 
-    detail::store_release(old_protect);
+    detail::store::release(old_protect);
   };
 
   r_vector(const writable::r_vector<T>& rhs) : r_vector(static_cast<SEXP>(rhs)) {}
@@ -189,7 +189,7 @@ class r_vector {
 
   const_iterator find(const r_string& name) const;
 
-  ~r_vector() { detail::store_release(protect_); }
+  ~r_vector() { detail::store::release(protect_); }
 
  private:
   SEXP data_ = R_NilValue;
@@ -371,7 +371,7 @@ class r_vector : public cpp11::r_vector<T> {
 template <typename T>
 inline r_vector<T>::r_vector(const SEXP data)
     : data_(valid_type(data)),
-      protect_(detail::store_insert(data)),
+      protect_(detail::store::insert(data)),
       is_altrep_(ALTREP(data)),
       data_p_(get_p(ALTREP(data), data)),
       length_(Rf_xlength(data)) {}
@@ -379,7 +379,7 @@ inline r_vector<T>::r_vector(const SEXP data)
 template <typename T>
 inline r_vector<T>::r_vector(const SEXP data, bool is_altrep)
     : data_(valid_type(data)),
-      protect_(detail::store_insert(data)),
+      protect_(detail::store::insert(data)),
       is_altrep_(is_altrep),
       data_p_(get_p(is_altrep, data)),
       length_(Rf_xlength(data)) {}
@@ -661,25 +661,25 @@ inline typename r_vector<T>::iterator r_vector<T>::end() const {
 template <typename T>
 inline r_vector<T>::r_vector(const SEXP& data)
     : cpp11::r_vector<T>(safe[Rf_shallow_duplicate](data)),
-      protect_(detail::store_insert(data_)),
+      protect_(detail::store::insert(data_)),
       capacity_(length_) {}
 
 template <typename T>
 inline r_vector<T>::r_vector(const SEXP& data, bool is_altrep)
     : cpp11::r_vector<T>(safe[Rf_shallow_duplicate](data), is_altrep),
-      protect_(detail::store_insert(data_)),
+      protect_(detail::store::insert(data_)),
       capacity_(length_) {}
 
 template <typename T>
 inline r_vector<T>::r_vector(SEXP&& data)
     : cpp11::r_vector<T>(data),
-      protect_(detail::store_insert(data_)),
+      protect_(detail::store::insert(data_)),
       capacity_(length_) {}
 
 template <typename T>
 inline r_vector<T>::r_vector(SEXP&& data, bool is_altrep)
     : cpp11::r_vector<T>(data, is_altrep),
-      protect_(detail::store_insert(data_)),
+      protect_(detail::store::insert(data_)),
       capacity_(length_) {}
 
 template <typename T>
@@ -711,7 +711,7 @@ inline r_vector<T>::r_vector(const R_xlen_t size) : r_vector() {
 
 template <typename T>
 inline r_vector<T>::~r_vector() {
-  detail::store_release(protect_);
+  detail::store::release(protect_);
 }
 
 #ifdef LONG_VECTOR_SUPPORT
@@ -794,7 +794,7 @@ inline typename r_vector<T>::iterator r_vector<T>::find(const r_string& name) co
 template <typename T>
 inline r_vector<T>::r_vector(const r_vector<T>& rhs)
     : cpp11::r_vector<T>(safe[Rf_shallow_duplicate](rhs)),
-      protect_(detail::store_insert(data_)),
+      protect_(detail::store::insert(data_)),
       capacity_(rhs.capacity_) {}
 
 template <typename T>
@@ -807,7 +807,7 @@ inline r_vector<T>::r_vector(r_vector<T>&& rhs)
 template <typename T>
 inline r_vector<T>::r_vector(const cpp11::r_vector<T>& rhs)
     : cpp11::r_vector<T>(safe[Rf_shallow_duplicate](rhs)),
-      protect_(detail::store_insert(data_)),
+      protect_(detail::store::insert(data_)),
       capacity_(rhs.length_) {}
 
 // We don't release the old object until the end in case we throw an exception
@@ -823,9 +823,9 @@ inline r_vector<T>& r_vector<T>::operator=(const r_vector<T>& rhs) {
   auto old_protect = protect_;
 
   data_ = safe[Rf_shallow_duplicate](rhs.data_);
-  protect_ = detail::store_insert(data_);
+  protect_ = detail::store::insert(data_);
 
-  detail::store_release(old_protect);
+  detail::store::release(old_protect);
 
   capacity_ = rhs.capacity_;
 
@@ -843,9 +843,9 @@ inline r_vector<T>& r_vector<T>::operator=(r_vector<T>&& rhs) {
   SEXP old_protect = protect_;
 
   data_ = rhs.data_;
-  protect_ = detail::store_insert(data_);
+  protect_ = detail::store::insert(data_);
 
-  detail::store_release(old_protect);
+  detail::store::release(old_protect);
 
   capacity_ = rhs.capacity_;
 

--- a/inst/include/cpp11/r_vector.hpp
+++ b/inst/include/cpp11/r_vector.hpp
@@ -672,7 +672,9 @@ inline r_vector<T>::r_vector(const SEXP& data, bool is_altrep)
 
 template <typename T>
 inline r_vector<T>::r_vector(SEXP&& data)
-    : cpp11::r_vector<T>(data), protect_(detail::store_insert(data_)), capacity_(length_) {}
+    : cpp11::r_vector<T>(data),
+      protect_(detail::store_insert(data_)),
+      capacity_(length_) {}
 
 template <typename T>
 inline r_vector<T>::r_vector(SEXP&& data, bool is_altrep)

--- a/inst/include/cpp11/raws.hpp
+++ b/inst/include/cpp11/raws.hpp
@@ -8,7 +8,7 @@
 #include "cpp11/R.hpp"                // for RAW, SEXP, SEXPREC, Rf_allocVector
 #include "cpp11/attribute_proxy.hpp"  // for attribute_proxy
 #include "cpp11/named_arg.hpp"        // for named_arg
-#include "cpp11/protect.hpp"          // for store_insert, store_release
+#include "cpp11/protect.hpp"          // for store
 #include "cpp11/r_vector.hpp"         // for r_vector, r_vector<>::proxy
 #include "cpp11/sexp.hpp"             // for sexp
 
@@ -88,7 +88,7 @@ template <>
 inline r_vector<uint8_t>::r_vector(std::initializer_list<uint8_t> il)
     : cpp11::r_vector<uint8_t>(safe[Rf_allocVector](RAWSXP, il.size())),
       capacity_(il.size()) {
-  protect_ = detail::store_insert(data_);
+  protect_ = detail::store::insert(data_);
   auto it = il.begin();
   for (R_xlen_t i = 0; i < capacity_; ++i, ++it) {
     data_p_[i] = *it;
@@ -99,7 +99,7 @@ template <>
 inline r_vector<uint8_t>::r_vector(std::initializer_list<named_arg> il)
     : cpp11::r_vector<uint8_t>(safe[Rf_allocVector](RAWSXP, il.size())),
       capacity_(il.size()) {
-  protect_ = detail::store_insert(data_);
+  protect_ = detail::store::insert(data_);
   int n_protected = 0;
 
   try {
@@ -116,7 +116,7 @@ inline r_vector<uint8_t>::r_vector(std::initializer_list<named_arg> il)
       UNPROTECT(n_protected);
     });
   } catch (const unwind_exception& e) {
-    detail::store_release(protect_);
+    detail::store::release(protect_);
     UNPROTECT(n_protected);
     throw e;
   }
@@ -128,8 +128,8 @@ inline void r_vector<uint8_t>::reserve(R_xlen_t new_capacity) {
                               : safe[Rf_xlengthgets](data_, new_capacity);
 
   SEXP old_protect = protect_;
-  protect_ = detail::store_insert(data_);
-  detail::store_release(old_protect);
+  protect_ = detail::store::insert(data_);
+  detail::store::release(old_protect);
 
   data_p_ = RAW(data_);
   capacity_ = new_capacity;

--- a/inst/include/cpp11/sexp.hpp
+++ b/inst/include/cpp11/sexp.hpp
@@ -6,7 +6,7 @@
 
 #include "cpp11/R.hpp"                // for SEXP, SEXPREC, REAL_ELT, R_NilV...
 #include "cpp11/attribute_proxy.hpp"  // for attribute_proxy
-#include "cpp11/protect.hpp"          // for store_insert, store_release
+#include "cpp11/protect.hpp"          // for store
 
 namespace cpp11 {
 
@@ -19,14 +19,14 @@ class sexp {
  public:
   sexp() = default;
 
-  sexp(SEXP data) : data_(data), preserve_token_(detail::store_insert(data_)) {
+  sexp(SEXP data) : data_(data), preserve_token_(detail::store::insert(data_)) {
     // REprintf("created %p %p\n", reinterpret_cast<void*>(data_),
     //          reinterpret_cast<void*>(preserve_token_));
   }
 
   sexp(const sexp& rhs) {
     data_ = rhs.data_;
-    preserve_token_ = detail::store_insert(data_);
+    preserve_token_ = detail::store::insert(data_);
     // REprintf("copied %p new protect %p\n", reinterpret_cast<void*>(rhs.data_),
     //          reinterpret_cast<void*>(preserve_token_));
   }
@@ -42,10 +42,10 @@ class sexp {
   }
 
   sexp& operator=(const sexp& rhs) {
-    detail::store_release(preserve_token_);
+    detail::store::release(preserve_token_);
 
     data_ = rhs.data_;
-    preserve_token_ = detail::store_insert(data_);
+    preserve_token_ = detail::store::insert(data_);
     // REprintf("assigned %p\n", reinterpret_cast<void*>(rhs.data_));
     return *this;
   }
@@ -56,7 +56,7 @@ class sexp {
   //*this = tmp;
   //}
 
-  ~sexp() { detail::store_release(preserve_token_); }
+  ~sexp() { detail::store::release(preserve_token_); }
 
   attribute_proxy<sexp> attr(const char* name) const {
     return attribute_proxy<sexp>(*this, name);

--- a/inst/include/cpp11/sexp.hpp
+++ b/inst/include/cpp11/sexp.hpp
@@ -6,7 +6,7 @@
 
 #include "cpp11/R.hpp"                // for SEXP, SEXPREC, REAL_ELT, R_NilV...
 #include "cpp11/attribute_proxy.hpp"  // for attribute_proxy
-#include "cpp11/protect.hpp"          // for preserved
+#include "cpp11/protect.hpp"          // for store_insert, store_release
 
 namespace cpp11 {
 
@@ -19,14 +19,14 @@ class sexp {
  public:
   sexp() = default;
 
-  sexp(SEXP data) : data_(data), preserve_token_(preserved.insert(data_)) {
+  sexp(SEXP data) : data_(data), preserve_token_(detail::store_insert(data_)) {
     // REprintf("created %p %p\n", reinterpret_cast<void*>(data_),
     //          reinterpret_cast<void*>(preserve_token_));
   }
 
   sexp(const sexp& rhs) {
     data_ = rhs.data_;
-    preserve_token_ = preserved.insert(data_);
+    preserve_token_ = detail::store_insert(data_);
     // REprintf("copied %p new protect %p\n", reinterpret_cast<void*>(rhs.data_),
     //          reinterpret_cast<void*>(preserve_token_));
   }
@@ -42,10 +42,10 @@ class sexp {
   }
 
   sexp& operator=(const sexp& rhs) {
-    preserved.release(preserve_token_);
+    detail::store_release(preserve_token_);
 
     data_ = rhs.data_;
-    preserve_token_ = preserved.insert(data_);
+    preserve_token_ = detail::store_insert(data_);
     // REprintf("assigned %p\n", reinterpret_cast<void*>(rhs.data_));
     return *this;
   }
@@ -56,7 +56,7 @@ class sexp {
   //*this = tmp;
   //}
 
-  ~sexp() { preserved.release(preserve_token_); }
+  ~sexp() { detail::store_release(preserve_token_); }
 
   attribute_proxy<sexp> attr(const char* name) const {
     return attribute_proxy<sexp>(*this, name);

--- a/inst/include/cpp11/strings.hpp
+++ b/inst/include/cpp11/strings.hpp
@@ -7,7 +7,7 @@
 #include "cpp11/as.hpp"               // for as_sexp
 #include "cpp11/attribute_proxy.hpp"  // for attribute_proxy
 #include "cpp11/named_arg.hpp"        // for named_arg
-#include "cpp11/protect.hpp"          // for preserved
+#include "cpp11/protect.hpp"          // for store_insert, store_release
 #include "cpp11/r_string.hpp"         // for r_string
 #include "cpp11/r_vector.hpp"         // for r_vector, r_vector<>::proxy
 #include "cpp11/sexp.hpp"             // for sexp
@@ -95,7 +95,7 @@ inline SEXP alloc_if_charsxp(const SEXP data) {
 template <>
 inline r_vector<r_string>::r_vector(const SEXP& data)
     : cpp11::r_vector<r_string>(alloc_or_copy(data)),
-      protect_(preserved.insert(data_)),
+      protect_(detail::store_insert(data_)),
       capacity_(length_) {
   if (TYPEOF(data) == CHARSXP) {
     SET_STRING_ELT(data_, 0, data);
@@ -105,7 +105,7 @@ inline r_vector<r_string>::r_vector(const SEXP& data)
 template <>
 inline r_vector<r_string>::r_vector(SEXP&& data)
     : cpp11::r_vector<r_string>(alloc_if_charsxp(data)),
-      protect_(preserved.insert(data_)),
+      protect_(detail::store_insert(data_)),
       capacity_(length_) {
   if (TYPEOF(data) == CHARSXP) {
     SET_STRING_ELT(data_, 0, data);
@@ -120,7 +120,7 @@ template <>
 inline r_vector<r_string>::r_vector(std::initializer_list<named_arg> il)
     : cpp11::r_vector<r_string>(safe[Rf_allocVector](STRSXP, il.size())),
       capacity_(il.size()) {
-  protect_ = preserved.insert(data_);
+  protect_ = detail::store_insert(data_);
   int n_protected = 0;
 
   try {
@@ -136,7 +136,7 @@ inline r_vector<r_string>::r_vector(std::initializer_list<named_arg> il)
       UNPROTECT(n_protected);
     });
   } catch (const unwind_exception& e) {
-    preserved.release(protect_);
+    detail::store_release(protect_);
     UNPROTECT(n_protected);
     throw e;
   }
@@ -148,8 +148,8 @@ inline void r_vector<r_string>::reserve(R_xlen_t new_capacity) {
                               : safe[Rf_xlengthgets](data_, new_capacity);
 
   SEXP old_protect = protect_;
-  protect_ = preserved.insert(data_);
-  preserved.release(old_protect);
+  protect_ = detail::store_insert(data_);
+  detail::store_release(old_protect);
 
   capacity_ = new_capacity;
 }

--- a/inst/include/cpp11/strings.hpp
+++ b/inst/include/cpp11/strings.hpp
@@ -7,7 +7,7 @@
 #include "cpp11/as.hpp"               // for as_sexp
 #include "cpp11/attribute_proxy.hpp"  // for attribute_proxy
 #include "cpp11/named_arg.hpp"        // for named_arg
-#include "cpp11/protect.hpp"          // for store_insert, store_release
+#include "cpp11/protect.hpp"          // for store
 #include "cpp11/r_string.hpp"         // for r_string
 #include "cpp11/r_vector.hpp"         // for r_vector, r_vector<>::proxy
 #include "cpp11/sexp.hpp"             // for sexp
@@ -95,7 +95,7 @@ inline SEXP alloc_if_charsxp(const SEXP data) {
 template <>
 inline r_vector<r_string>::r_vector(const SEXP& data)
     : cpp11::r_vector<r_string>(alloc_or_copy(data)),
-      protect_(detail::store_insert(data_)),
+      protect_(detail::store::insert(data_)),
       capacity_(length_) {
   if (TYPEOF(data) == CHARSXP) {
     SET_STRING_ELT(data_, 0, data);
@@ -105,7 +105,7 @@ inline r_vector<r_string>::r_vector(const SEXP& data)
 template <>
 inline r_vector<r_string>::r_vector(SEXP&& data)
     : cpp11::r_vector<r_string>(alloc_if_charsxp(data)),
-      protect_(detail::store_insert(data_)),
+      protect_(detail::store::insert(data_)),
       capacity_(length_) {
   if (TYPEOF(data) == CHARSXP) {
     SET_STRING_ELT(data_, 0, data);
@@ -120,7 +120,7 @@ template <>
 inline r_vector<r_string>::r_vector(std::initializer_list<named_arg> il)
     : cpp11::r_vector<r_string>(safe[Rf_allocVector](STRSXP, il.size())),
       capacity_(il.size()) {
-  protect_ = detail::store_insert(data_);
+  protect_ = detail::store::insert(data_);
   int n_protected = 0;
 
   try {
@@ -136,7 +136,7 @@ inline r_vector<r_string>::r_vector(std::initializer_list<named_arg> il)
       UNPROTECT(n_protected);
     });
   } catch (const unwind_exception& e) {
-    detail::store_release(protect_);
+    detail::store::release(protect_);
     UNPROTECT(n_protected);
     throw e;
   }
@@ -148,8 +148,8 @@ inline void r_vector<r_string>::reserve(R_xlen_t new_capacity) {
                               : safe[Rf_xlengthgets](data_, new_capacity);
 
   SEXP old_protect = protect_;
-  protect_ = detail::store_insert(data_);
-  detail::store_release(old_protect);
+  protect_ = detail::store::insert(data_);
+  detail::store::release(old_protect);
 
   capacity_ = new_capacity;
 }

--- a/vignettes/internals.Rmd
+++ b/vignettes/internals.Rmd
@@ -126,8 +126,8 @@ Each node in the list uses the head (`CAR`) part to point to the previous node, 
 The `TAG` is used to point to the object being protected.
 The head and tail of the list have `R_NilValue` as their `CAR` and `CDR` pointers respectively.
 
-Calling `cpp11::detail::store_insert()` with a regular R object will add a new node to the list and return a protect token corresponding to the node added.
-Calling `cpp11::detail::store_release()` on this returned token will release the protection by unlinking the node from the linked list.
+Calling `cpp11::detail::store::insert()` with a regular R object will add a new node to the list and return a protect token corresponding to the node added.
+Calling `cpp11::detail::store::release()` on this returned token will release the protection by unlinking the node from the linked list.
 These two functions are considered internal to cpp11, so do not use them in your packages.
 
 This scheme scales in O(1) time to release or insert an object vs O(N) or worse time with `R_PreserveObject()` / `R_ReleaseObject()`.

--- a/vignettes/internals.Rmd
+++ b/vignettes/internals.Rmd
@@ -126,15 +126,16 @@ Each node in the list uses the head (`CAR`) part to point to the previous node, 
 The `TAG` is used to point to the object being protected.
 The head and tail of the list have `R_NilValue` as their `CAR` and `CDR` pointers respectively.
 
-Calling `preserved.insert()` with a regular R object will add a new node to the list and return a protect token corresponding to the node added.
-Calling `preserved.release()` on this returned token will release the protection by unlinking the node from the linked list.
+Calling `cpp11::detail::store_insert()` with a regular R object will add a new node to the list and return a protect token corresponding to the node added.
+Calling `cpp11::detail::store_release()` on this returned token will release the protection by unlinking the node from the linked list.
+These two functions are considered internal to cpp11, so do not use them in your packages.
 
 This scheme scales in O(1) time to release or insert an object vs O(N) or worse time with `R_PreserveObject()` / `R_ReleaseObject()`.
 
-Each compilation unit has its own unique protection list, which avoids the need to manage a "global" protection list shared across compilation units within the same package and across packages.
-A previous version of cpp11 used a global protection list, but this caused [multiple issues](https://github.com/r-lib/cpp11/issues/330).
+Each package has its own unique protection list, which avoids the need to manage a "global" protection list shared across packages.
+A previous version of cpp11 used a global protection list stored in an R global option, but this caused [multiple issues](https://github.com/r-lib/cpp11/issues/330).
 
-These functions are defined in [protect.hpp](https://github.com/r-lib/cpp11/blob/main/inst/include/cpp11/protect.hpp)
+These functions are defined in [protect.hpp](https://github.com/r-lib/cpp11/blob/main/inst/include/cpp11/protect.hpp).
 
 ### Unwind Protect
 


### PR DESCRIPTION
Closes https://github.com/r-lib/cpp11/issues/249 as a cool side effect

The `preserved` static struct object has been removed in favor of some inline functions `detail::store::insert()` and `detail::store::release()`. These both access the preserve list through a _static local SEXP in an extern function_ called `detail::store::get()`. This exact setup is guaranteed by the standard to mean that the preserve list is _unique across compilation units_ in the package (see notes and links to SO and the standard in `protect.hpp`).

While working on https://github.com/r-lib/cpp11/pull/366, I learned that the current approach with the static `preserved` seems to have some issues anyways. The tests I implemented there were not consistently passing on all platforms, and seemed to change on my Mac depending on whether or not I compiled with optimization, making me think we were in undefined behavior land previously. I confirmed that everything works as expected with this new standard approved approach.
