### PR TITLE
Fix memory leak with move assignment operator

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # cpp11 (development version)
 
+* Fixed a memory leak with the `cpp11::writable::r_vector` move assignment
+  operator (#338).
+
 * The approach for the protection list managed by cpp11 has been tweaked
   slightly. In 0.4.6, we changed to an approach that creates one protection list
   per compilation unit, but we now believe we've found an approach that is

--- a/cpp11test/src/test-list.cpp
+++ b/cpp11test/src/test-list.cpp
@@ -2,6 +2,7 @@
 #include "cpp11/integers.hpp"
 #include "cpp11/list.hpp"
 #include "cpp11/logicals.hpp"
+#include "cpp11/protect.hpp"
 #include "cpp11/raws.hpp"
 #include "cpp11/strings.hpp"
 
@@ -161,5 +162,23 @@ context("list-C++") {
 
     expect_true(Rf_xlength(y) == 0);
     expect_true(y != R_NilValue);
+  }
+
+  test_that("writable list vector temporary isn't leaked (#338)") {
+    R_xlen_t before = cpp11::detail::store::count();
+
+    // +1 from `x` allocation
+    cpp11::writable::list x(1);
+
+    // Calls move assignment operator `operator=(r_vector<T>&& rhs)`
+    // +1 from `rhs` allocation and move into `x`
+    // -1 from old `x` release
+    x = cpp11::writable::list(1);
+
+    R_xlen_t after = cpp11::detail::store::count();
+
+    expect_true(before == 0);
+    // TODO: This should be 1 but writable vectors are being double protected
+    expect_true(after - before == 2);
   }
 }

--- a/inst/include/cpp11/r_vector.hpp
+++ b/inst/include/cpp11/r_vector.hpp
@@ -843,7 +843,7 @@ inline r_vector<T>& r_vector<T>::operator=(r_vector<T>&& rhs) {
   SEXP old_protect = protect_;
 
   data_ = rhs.data_;
-  protect_ = detail::store::insert(data_);
+  protect_ = rhs.protect_;
 
   detail::store::release(old_protect);
 


### PR DESCRIPTION
Closes #338 

This is rather complicated, and is caught up in the fact that we currently double protect all writable r_vectors (oops), but this is the minimal fix for #338. More changes are coming to simplify things further.

Here's the basic idea of what was happening (glossing over double protect weirdness). Take this example:

```cpp
cpp11::writable::integers x(1);
x = cpp11::writable::integers(1);
```

Here are the protection counts:

- `+1 x` The constructor creates `x` and protects it
- `+1 <temp>` An rvalue (temporary) of `cpp11::writable::integers(1)` is created and protected
- `+1 <temp>` WRONG! The move assignment operator is re-protecting the rvalue SEXP as it takes ownership of it rather than just taking the protect token from the rhs.
- `-1 x` The move assignment operator releases old `x`
- The move assignment operator sets `rhs.protect_ = R_NilValue` so when rhs is destructed, it can't release anything

So if you add that up you end with a `+2` count of items protected in the protection list when it should be `+1`, and that was indeed what I was seeing in my new tests. The memory of the `<temp>` value can never be released because the protection list always holds a reference to it.

The solution is simple - we just _move_ the `rhs.protect_` value into `x` rather than generating our own. This was probably the intention the whole time anyways, since we were also doing `rhs.protect_ = R_NilValue` at the end.