### PR TITLE
Clean up read-only `r_vector` declaration / implementation split

### DIFF
--- a/inst/include/cpp11/list_of.hpp
+++ b/inst/include/cpp11/list_of.hpp
@@ -13,10 +13,10 @@ class list_of : public list {
   list_of(const list& data) : list(data) {}
 
 #ifdef LONG_VECTOR_SUPPORT
-  T operator[](int pos) const { return operator[](static_cast<R_xlen_t>(pos)); }
+  T operator[](const int pos) const { return operator[](static_cast<R_xlen_t>(pos)); }
 #endif
 
-  T operator[](R_xlen_t pos) const { return list::operator[](pos); }
+  T operator[](const R_xlen_t pos) const { return list::operator[](pos); }
 
   T operator[](const char* pos) const { return list::operator[](pos); }
 


### PR DESCRIPTION
Should make it much easier to understand the classes just by looking at the class definition now, with all implementations separated out below

Also fixed a few minor inconsistencies, like a declaration requesting `const R_xlen_t pos` but the impl using `R_xlen_t pos`, not a big deal.

No behavior changes