### PR TITLE
Use a universal `reserve()` method

### DIFF
--- a/inst/include/cpp11/doubles.hpp
+++ b/inst/include/cpp11/doubles.hpp
@@ -55,6 +55,11 @@ typedef r_vector<double> doubles;
 namespace writable {
 
 template <>
+inline SEXPTYPE r_vector<double>::get_sexptype() {
+  return REALSXP;
+}
+
+template <>
 inline typename r_vector<double>::proxy& r_vector<double>::proxy::operator=(
     const double& rhs) {
   if (is_altrep_) {
@@ -102,18 +107,6 @@ inline r_vector<double>::r_vector(std::initializer_list<named_arg> il)
     UNPROTECT(n_protected);
     throw e;
   }
-}
-
-template <>
-inline void r_vector<double>::reserve(R_xlen_t new_capacity) {
-  data_ = data_ == R_NilValue ? safe[Rf_allocVector](REALSXP, new_capacity)
-                              : safe[Rf_xlengthgets](data_, new_capacity);
-  SEXP old_protect = protect_;
-  protect_ = detail::store::insert(data_);
-  detail::store::release(old_protect);
-
-  data_p_ = REAL(data_);
-  capacity_ = new_capacity;
 }
 
 template <>

--- a/inst/include/cpp11/integers.hpp
+++ b/inst/include/cpp11/integers.hpp
@@ -56,6 +56,11 @@ typedef r_vector<int> integers;
 namespace writable {
 
 template <>
+inline SEXPTYPE r_vector<int>::get_sexptype() {
+  return INTSXP;
+}
+
+template <>
 inline typename r_vector<int>::proxy& r_vector<int>::proxy::operator=(const int& rhs) {
   if (is_altrep_) {
     // NOPROTECT: likely too costly to unwind protect every set elt
@@ -79,22 +84,6 @@ inline r_vector<int>::proxy::operator int() const {
 template <>
 inline r_vector<int>::r_vector(std::initializer_list<int> il)
     : cpp11::r_vector<int>(as_sexp(il)), capacity_(il.size()) {}
-
-template <>
-inline void r_vector<int>::reserve(R_xlen_t new_capacity) {
-  data_ = data_ == R_NilValue ? safe[Rf_allocVector](INTSXP, new_capacity)
-                              : safe[Rf_xlengthgets](data_, new_capacity);
-  SEXP old_protect = protect_;
-
-  // Protect the new data
-  protect_ = detail::store::insert(data_);
-
-  // Release the old protection;
-  detail::store::release(old_protect);
-
-  data_p_ = INTEGER(data_);
-  capacity_ = new_capacity;
-}
 
 template <>
 inline r_vector<int>::r_vector(std::initializer_list<named_arg> il)

--- a/inst/include/cpp11/list.hpp
+++ b/inst/include/cpp11/list.hpp
@@ -64,6 +64,11 @@ typedef r_vector<SEXP> list;
 namespace writable {
 
 template <>
+inline SEXPTYPE r_vector<SEXP>::get_sexptype() {
+  return VECSXP;
+}
+
+template <>
 inline typename r_vector<SEXP>::proxy& r_vector<SEXP>::proxy::operator=(const SEXP& rhs) {
   SET_VECTOR_ELT(data_, index_, rhs);
   return *this;
@@ -106,18 +111,6 @@ inline r_vector<SEXP>::r_vector(std::initializer_list<named_arg> il)
     UNPROTECT(n_protected);
     throw e;
   }
-}
-
-template <>
-inline void r_vector<SEXP>::reserve(R_xlen_t new_capacity) {
-  data_ = data_ == R_NilValue ? safe[Rf_allocVector](VECSXP, new_capacity)
-                              : safe[Rf_xlengthgets](data_, new_capacity);
-
-  SEXP old_protect = protect_;
-  protect_ = detail::store::insert(data_);
-  detail::store::release(old_protect);
-
-  capacity_ = new_capacity;
 }
 
 template <>

--- a/inst/include/cpp11/logicals.hpp
+++ b/inst/include/cpp11/logicals.hpp
@@ -54,6 +54,11 @@ typedef r_vector<r_bool> logicals;
 namespace writable {
 
 template <>
+inline SEXPTYPE r_vector<r_bool>::get_sexptype() {
+  return LGLSXP;
+}
+
+template <>
 inline typename r_vector<r_bool>::proxy& r_vector<r_bool>::proxy::operator=(
     const r_bool& rhs) {
   if (is_altrep_) {
@@ -108,19 +113,6 @@ inline r_vector<r_bool>::r_vector(std::initializer_list<named_arg> il)
     UNPROTECT(n_protected);
     throw e;
   }
-}
-
-template <>
-inline void r_vector<r_bool>::reserve(R_xlen_t new_capacity) {
-  data_ = data_ == R_NilValue ? safe[Rf_allocVector](LGLSXP, new_capacity)
-                              : safe[Rf_xlengthgets](data_, new_capacity);
-  SEXP old_protect = protect_;
-  protect_ = detail::store::insert(data_);
-
-  detail::store::release(old_protect);
-
-  data_p_ = LOGICAL(data_);
-  capacity_ = new_capacity;
 }
 
 template <>

--- a/inst/include/cpp11/raws.hpp
+++ b/inst/include/cpp11/raws.hpp
@@ -63,6 +63,11 @@ typedef r_vector<uint8_t> raws;
 namespace writable {
 
 template <>
+inline SEXPTYPE r_vector<uint8_t>::get_sexptype() {
+  return RAWSXP;
+}
+
+template <>
 inline typename r_vector<uint8_t>::proxy& r_vector<uint8_t>::proxy::operator=(
     const uint8_t& rhs) {
   if (is_altrep_) {
@@ -117,19 +122,6 @@ inline r_vector<uint8_t>::r_vector(std::initializer_list<named_arg> il)
     UNPROTECT(n_protected);
     throw e;
   }
-}
-
-template <>
-inline void r_vector<uint8_t>::reserve(R_xlen_t new_capacity) {
-  data_ = data_ == R_NilValue ? safe[Rf_allocVector](RAWSXP, new_capacity)
-                              : safe[Rf_xlengthgets](data_, new_capacity);
-
-  SEXP old_protect = protect_;
-  protect_ = detail::store::insert(data_);
-  detail::store::release(old_protect);
-
-  data_p_ = RAW(data_);
-  capacity_ = new_capacity;
 }
 
 template <>

--- a/inst/include/cpp11/strings.hpp
+++ b/inst/include/cpp11/strings.hpp
@@ -54,6 +54,11 @@ typedef r_vector<r_string> strings;
 namespace writable {
 
 template <>
+inline SEXPTYPE r_vector<r_string>::get_sexptype() {
+  return STRSXP;
+}
+
+template <>
 inline typename r_vector<r_string>::proxy& r_vector<r_string>::proxy::operator=(
     const r_string& rhs) {
   unwind_protect([&] { SET_STRING_ELT(data_, index_, rhs); });
@@ -134,18 +139,6 @@ inline r_vector<r_string>::r_vector(std::initializer_list<named_arg> il)
     UNPROTECT(n_protected);
     throw e;
   }
-}
-
-template <>
-inline void r_vector<r_string>::reserve(R_xlen_t new_capacity) {
-  data_ = data_ == R_NilValue ? safe[Rf_allocVector](STRSXP, new_capacity)
-                              : safe[Rf_xlengthgets](data_, new_capacity);
-
-  SEXP old_protect = protect_;
-  protect_ = detail::store::insert(data_);
-  detail::store::release(old_protect);
-
-  capacity_ = new_capacity;
 }
 
 template <>


### PR DESCRIPTION
Closes https://github.com/r-lib/cpp11/issues/368 - this issue doesn't matter too much, but if you start as a writable ALTREP object and then call `push_back()` and that resizes the vector, then it will still look like an ALTREP object even though `Rf_xlengthgets()` will never produce an ALTREP object. The right thing to do is to always recompute the flag from the newly allocated object.

When working on this, I realized we could unify the `reserve()` methods, removing a lot of duplication, which is great. It now also sets the `data_p_` for VECSXP and STRSXP which was not happening before, but `get_p()` will always return `nullptr` for these types, so no harm done.