### PR TITLE
Unify `initializer_list<T>` constructors

### DIFF
--- a/cpp11test/src/test-doubles.cpp
+++ b/cpp11test/src/test-doubles.cpp
@@ -175,6 +175,14 @@ context("doubles-C++") {
 
     UNPROTECT(1);
   }
+
+  test_that("writable::doubles(initializer_list<double>)") {
+    cpp11::writable::doubles x({1, 2.5, 3});
+    expect_true(x[0] == 1.0);
+    expect_true(x[1] == 2.5);
+    expect_true(x[2] == 3.0);
+  }
+
   test_that("writable::doubles(SEXP, bool)") {
     SEXP x = PROTECT(Rf_ScalarReal(5.));
     cpp11::writable::doubles y(x, false);

--- a/cpp11test/src/test-integers.cpp
+++ b/cpp11test/src/test-integers.cpp
@@ -168,6 +168,13 @@ context("integers-C++") {
     UNPROTECT(1);
   }
 
+  test_that("writable::integers(initializer_list<int>)") {
+    cpp11::writable::integers x({1, 2, 3});
+    expect_true(x[0] == 1);
+    expect_true(x[1] == 2);
+    expect_true(x[2] == 3);
+  }
+
 #if defined(__APPLE__) && defined(R_VERSION) && R_VERSION >= R_Version(3, 5, 0)
   test_that("writable::integers(ALTREP_SEXP)") {
     // ALTREP compact-seq

--- a/cpp11test/src/test-list.cpp
+++ b/cpp11test/src/test-list.cpp
@@ -163,4 +163,17 @@ context("list-C++") {
     expect_true(Rf_xlength(y) == 0);
     expect_true(y != R_NilValue);
   }
+
+  test_that("writable::list(initializer_list<SEXP>)") {
+    SEXP x1 = PROTECT(Rf_allocVector(INTSXP, 1));
+    SEXP x2 = PROTECT(Rf_allocVector(REALSXP, 2));
+    SEXP x3 = PROTECT(Rf_allocVector(STRSXP, 3));
+
+    cpp11::writable::list x({x1, x2, x3});
+    expect_true(x[0] == x1);
+    expect_true(x[1] == x2);
+    expect_true(x[2] == x3);
+
+    UNPROTECT(3);
+  }
 }

--- a/cpp11test/src/test-logicals.cpp
+++ b/cpp11test/src/test-logicals.cpp
@@ -127,6 +127,27 @@ context("logicals-C++") {
 
     UNPROTECT(1);
   }
+
+  test_that("writable::logicals(initializer_list<r_bool>)") {
+    cpp11::writable::logicals x(
+        {cpp11::r_bool(true), cpp11::r_bool(false), cpp11::r_bool(NA_INTEGER)});
+    expect_true(x[0] == cpp11::r_bool(true));
+    expect_true(x[1] == cpp11::r_bool(false));
+    expect_true(x[2] == cpp11::r_bool(NA_INTEGER));
+
+    // This works due to implicit conversion of `bool` to `r_bool`
+    cpp11::writable::logicals y({true, false, false});
+    expect_true(y[0] == cpp11::r_bool(true));
+    expect_true(y[1] == cpp11::r_bool(false));
+    expect_true(y[2] == cpp11::r_bool(false));
+
+    // This works due to implicit conversion of `Rboolean` to `r_bool`
+    cpp11::writable::logicals z({TRUE, FALSE, FALSE});
+    expect_true(z[0] == cpp11::r_bool(true));
+    expect_true(z[1] == cpp11::r_bool(false));
+    expect_true(z[2] == cpp11::r_bool(false));
+  }
+
   test_that("is_na(r_bool)") {
     cpp11::r_bool x = TRUE;
     expect_true(!cpp11::is_na(x));

--- a/cpp11test/src/test-raws.cpp
+++ b/cpp11test/src/test-raws.cpp
@@ -128,6 +128,13 @@ context("raws-C++") {
     UNPROTECT(1);
   }
 
+  test_that("writable::raws(initializer_list<uint_8>)") {
+    cpp11::writable::raws x({1, 2, 255});
+    expect_true(x[0] == 1);
+    expect_true(x[1] == 2);
+    expect_true(x[2] == 255);
+  }
+
   // test_that("writable::raws(ALTREP_SEXP)") {
   // SEXP x = PROTECT(R_compact_uint8_trange(1, 5));
   //// Need to find (or create) an altrep class that implements duplicate.

--- a/cpp11test/src/test-strings.cpp
+++ b/cpp11test/src/test-strings.cpp
@@ -133,6 +133,34 @@ context("strings-C++") {
     UNPROTECT(1);
   }
 
+  test_that("writable::strings(initializer_list<r_string>)") {
+    cpp11::r_string abc = cpp11::r_string("abc");
+    cpp11::r_string na = cpp11::r_string(NA_STRING);
+
+    cpp11::writable::strings x({abc, na, abc});
+    expect_true(x[0] == abc);
+    expect_true(x[1] == na);
+    expect_true(x[2] == abc);
+
+    // This works due to implicit conversion of `SEXP` to `r_string`
+    SEXP a = PROTECT(Rf_mkCharCE("a", CE_UTF8));
+    SEXP b = PROTECT(Rf_mkCharCE("b", CE_UTF8));
+    cpp11::writable::strings y({a, b});
+    expect_true(y[0] == cpp11::r_string("a"));
+    expect_true(y[1] == cpp11::r_string("b"));
+
+    // This works due to implicit conversion of `const char*` to `r_string`
+    cpp11::writable::strings z({"neat", "stuff"});
+    expect_true(z[0] == cpp11::r_string("neat"));
+    expect_true(z[1] == cpp11::r_string("stuff"));
+
+    cpp11::writable::strings w({std::string("neat"), std::string("stuff")});
+    expect_true(w[0] == cpp11::r_string("neat"));
+    expect_true(w[1] == cpp11::r_string("stuff"));
+
+    UNPROTECT(2);
+  }
+
   test_that("std::initializer_list<const char*>") {
     cpp11::writable::strings x{"foo"};
     expect_true(x.size() == 1);

--- a/inst/include/cpp11/doubles.hpp
+++ b/inst/include/cpp11/doubles.hpp
@@ -60,6 +60,12 @@ inline SEXPTYPE r_vector<double>::get_sexptype() {
 }
 
 template <>
+inline void r_vector<double>::set_elt(
+    SEXP x, R_xlen_t i, typename traits::get_underlying_type<double>::type value) {
+  SET_REAL_ELT(x, i, value);
+}
+
+template <>
 inline typename r_vector<double>::proxy& r_vector<double>::proxy::operator=(
     const double& rhs) {
   if (is_altrep_) {
@@ -80,10 +86,6 @@ inline r_vector<double>::proxy::operator double() const {
     return *p_;
   }
 }
-
-template <>
-inline r_vector<double>::r_vector(std::initializer_list<double> il)
-    : cpp11::r_vector<double>(as_sexp(il)), capacity_(il.size()) {}
 
 template <>
 inline r_vector<double>::r_vector(std::initializer_list<named_arg> il)

--- a/inst/include/cpp11/integers.hpp
+++ b/inst/include/cpp11/integers.hpp
@@ -61,6 +61,12 @@ inline SEXPTYPE r_vector<int>::get_sexptype() {
 }
 
 template <>
+inline void r_vector<int>::set_elt(
+    SEXP x, R_xlen_t i, typename traits::get_underlying_type<int>::type value) {
+  SET_INTEGER_ELT(x, i, value);
+}
+
+template <>
 inline typename r_vector<int>::proxy& r_vector<int>::proxy::operator=(const int& rhs) {
   if (is_altrep_) {
     // NOPROTECT: likely too costly to unwind protect every set elt
@@ -80,10 +86,6 @@ inline r_vector<int>::proxy::operator int() const {
     return *p_;
   }
 }
-
-template <>
-inline r_vector<int>::r_vector(std::initializer_list<int> il)
-    : cpp11::r_vector<int>(as_sexp(il)), capacity_(il.size()) {}
 
 template <>
 inline r_vector<int>::r_vector(std::initializer_list<named_arg> il)

--- a/inst/include/cpp11/list.hpp
+++ b/inst/include/cpp11/list.hpp
@@ -69,6 +69,12 @@ inline SEXPTYPE r_vector<SEXP>::get_sexptype() {
 }
 
 template <>
+inline void r_vector<SEXP>::set_elt(
+    SEXP x, R_xlen_t i, typename traits::get_underlying_type<SEXP>::type value) {
+  SET_VECTOR_ELT(x, i, value);
+}
+
+template <>
 inline typename r_vector<SEXP>::proxy& r_vector<SEXP>::proxy::operator=(const SEXP& rhs) {
   SET_VECTOR_ELT(data_, index_, rhs);
   return *this;
@@ -77,16 +83,6 @@ inline typename r_vector<SEXP>::proxy& r_vector<SEXP>::proxy::operator=(const SE
 template <>
 inline r_vector<SEXP>::proxy::operator SEXP() const {
   return VECTOR_ELT(data_, index_);
-}
-
-template <>
-inline r_vector<SEXP>::r_vector(std::initializer_list<SEXP> il)
-    : cpp11::r_vector<SEXP>(safe[Rf_allocVector](VECSXP, il.size())),
-      capacity_(il.size()) {
-  auto it = il.begin();
-  for (R_xlen_t i = 0; i < capacity_; ++i, ++it) {
-    SET_VECTOR_ELT(data_, i, *it);
-  }
 }
 
 template <>

--- a/inst/include/cpp11/logicals.hpp
+++ b/inst/include/cpp11/logicals.hpp
@@ -59,6 +59,12 @@ inline SEXPTYPE r_vector<r_bool>::get_sexptype() {
 }
 
 template <>
+inline void r_vector<r_bool>::set_elt(
+    SEXP x, R_xlen_t i, typename traits::get_underlying_type<r_bool>::type value) {
+  SET_LOGICAL_ELT(x, i, value);
+}
+
+template <>
 inline typename r_vector<r_bool>::proxy& r_vector<r_bool>::proxy::operator=(
     const r_bool& rhs) {
   if (is_altrep_) {
@@ -80,15 +86,6 @@ inline r_vector<r_bool>::proxy::operator r_bool() const {
 
 inline bool operator==(const r_vector<r_bool>::proxy& lhs, r_bool rhs) {
   return static_cast<r_bool>(lhs).operator==(rhs);
-}
-
-template <>
-inline r_vector<r_bool>::r_vector(std::initializer_list<r_bool> il)
-    : cpp11::r_vector<r_bool>(Rf_allocVector(LGLSXP, il.size())), capacity_(il.size()) {
-  auto it = il.begin();
-  for (R_xlen_t i = 0; i < capacity_; ++i, ++it) {
-    SET_LOGICAL_ELT(data_, i, *it);
-  }
 }
 
 template <>

--- a/inst/include/cpp11/raws.hpp
+++ b/inst/include/cpp11/raws.hpp
@@ -5,6 +5,7 @@
 #include <cstdint>           // for uint8_t
 #include <initializer_list>  // for initializer_list
 
+#include "Rversion.h"
 #include "cpp11/R.hpp"                // for RAW, SEXP, SEXPREC, Rf_allocVector
 #include "cpp11/attribute_proxy.hpp"  // for attribute_proxy
 #include "cpp11/named_arg.hpp"        // for named_arg
@@ -68,6 +69,16 @@ inline SEXPTYPE r_vector<uint8_t>::get_sexptype() {
 }
 
 template <>
+inline void r_vector<uint8_t>::set_elt(
+    SEXP x, R_xlen_t i, typename traits::get_underlying_type<uint8_t>::type value) {
+#if R_VERSION >= R_Version(4, 2, 0)
+  SET_RAW_ELT(x, i, value);
+#else
+  RAW(x)[i] = value;
+#endif
+}
+
+template <>
 inline typename r_vector<uint8_t>::proxy& r_vector<uint8_t>::proxy::operator=(
     const uint8_t& rhs) {
   if (is_altrep_) {
@@ -86,16 +97,6 @@ inline r_vector<uint8_t>::proxy::operator uint8_t() const {
     return RAW(data_)[index_];
   } else {
     return *p_;
-  }
-}
-
-template <>
-inline r_vector<uint8_t>::r_vector(std::initializer_list<uint8_t> il)
-    : cpp11::r_vector<uint8_t>(safe[Rf_allocVector](RAWSXP, il.size())),
-      capacity_(il.size()) {
-  auto it = il.begin();
-  for (R_xlen_t i = 0; i < capacity_; ++i, ++it) {
-    data_p_[i] = *it;
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/r-lib/cpp11/issues/375

Strings are a bit complicated and require their own specialization, but in general this works nicely