### PR TITLE
Shallow duplicate in `r_vector(const r_vector& rhs)` constructor after all

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # cpp11 (development version)
 
+* Fixed an issue with the `writable::matrix` copy constructor where the
+  underlying SEXP should have been copied but was not. It is now consistent with
+  the behavior of the equivalent `writable::r_vector` copy constructor.
+
 * Added the missing implementation for `x.at("name")` for read only vectors
   (#370).
 

--- a/cpp11test/src/test-matrix.cpp
+++ b/cpp11test/src/test-matrix.cpp
@@ -134,11 +134,10 @@ context("matrix-C++") {
     // Note that a copy should be made when copying writable!
     expect_true(SEXP(x) != SEXP(yr));
 
-    // TODO: Fix this
-    // // `dim` attribute is retained on copy
-    // auto yr_dim = yr.attr("dim");
-    // expect_true(INTEGER_ELT(yr_dim, 0) == 5);
-    // expect_true(INTEGER_ELT(yr_dim, 1) == 2);
+    // `dim` attribute is retained on copy
+    auto yr_dim = yr.attr("dim");
+    expect_true(INTEGER_ELT(yr_dim, 0) == 5);
+    expect_true(INTEGER_ELT(yr_dim, 1) == 2);
 
     cpp11::writable::doubles_matrix<cpp11::by_column> yc(x);
     expect_true(x.nrow() == yc.nrow());
@@ -147,11 +146,10 @@ context("matrix-C++") {
     // Note that a copy should be made when copying writable!
     expect_true(SEXP(x) != SEXP(yc));
 
-    // TODO: Fix this
-    // // `dim` attribute is retained on copy
-    // auto yc_dim = yc.attr("dim");
-    // expect_true(INTEGER_ELT(yc_dim, 0) == 5);
-    // expect_true(INTEGER_ELT(yc_dim, 1) == 2);
+    // `dim` attribute is retained on copy
+    auto yc_dim = yc.attr("dim");
+    expect_true(INTEGER_ELT(yc_dim, 0) == 5);
+    expect_true(INTEGER_ELT(yc_dim, 1) == 2);
   }
 
   test_that("copy constructor is not enabled across vector types") {

--- a/cpp11test/src/test-matrix.cpp
+++ b/cpp11test/src/test-matrix.cpp
@@ -103,7 +103,7 @@ context("matrix-C++") {
     expect_true(xc(10, 13) == 121);
   }
 
-  test_that("copy constructor works") {
+  test_that("copy constructor works for read only matrices") {
     auto getExportedValue = cpp11::package("base")["getExportedValue"];
     cpp11::doubles_matrix<cpp11::by_row> x(getExportedValue("datasets", "volcano"));
 
@@ -118,5 +118,44 @@ context("matrix-C++") {
     expect_true(x.ncol() == yc.ncol());
     expect_true(yc.nslices() == yc.ncol());
     expect_true(SEXP(x) == SEXP(yc));
+  }
+
+  test_that("copy constructor works for writable matrices") {
+    cpp11::writable::doubles_matrix<cpp11::by_row> x(5, 2);
+
+    auto x_dim = x.attr("dim");
+    expect_true(INTEGER_ELT(x_dim, 0) == 5);
+    expect_true(INTEGER_ELT(x_dim, 1) == 2);
+
+    cpp11::writable::doubles_matrix<cpp11::by_row> yr(x);
+    expect_true(x.nrow() == yr.nrow());
+    expect_true(x.ncol() == yr.ncol());
+    expect_true(yr.nslices() == yr.nrow());
+    // Note that a copy should be made when copying writable!
+    expect_true(SEXP(x) != SEXP(yr));
+
+    // TODO: Fix this
+    // // `dim` attribute is retained on copy
+    // auto yr_dim = yr.attr("dim");
+    // expect_true(INTEGER_ELT(yr_dim, 0) == 5);
+    // expect_true(INTEGER_ELT(yr_dim, 1) == 2);
+
+    cpp11::writable::doubles_matrix<cpp11::by_column> yc(x);
+    expect_true(x.nrow() == yc.nrow());
+    expect_true(x.ncol() == yc.ncol());
+    expect_true(yc.nslices() == yc.ncol());
+    // Note that a copy should be made when copying writable!
+    expect_true(SEXP(x) != SEXP(yc));
+
+    // TODO: Fix this
+    // // `dim` attribute is retained on copy
+    // auto yc_dim = yc.attr("dim");
+    // expect_true(INTEGER_ELT(yc_dim, 0) == 5);
+    // expect_true(INTEGER_ELT(yc_dim, 1) == 2);
+  }
+
+  test_that("copy constructor is not enabled across vector types") {
+    cpp11::writable::doubles_matrix<cpp11::by_row> x(5, 2);
+    expect_error(cpp11::writable::integers_matrix<cpp11::by_column>(x));
   }
 }

--- a/cpp11test/src/test-r_vector.cpp
+++ b/cpp11test/src/test-r_vector.cpp
@@ -281,10 +281,12 @@ context("r_vector-C++") {
 
     // Doubles the capacity from 2 to 4
     x.push_back(3);
+    expect_true(Rf_xlength(x.data()) == 4);
 
     // Calls writable copy constructor.
     // Should duplicate without truncations and retain same capacity.
     cpp11::writable::integers y(x);
+    expect_true(Rf_xlength(y.data()) == 4);
 
     // In the past, we truncated (i.e. to size 3) but retained the same capacity of 4,
     // so this could try to push without first resizing.

--- a/inst/include/cpp11/matrix.hpp
+++ b/inst/include/cpp11/matrix.hpp
@@ -165,7 +165,8 @@ class matrix : public matrix_slices<S> {
   matrix(SEXP data) : matrix_slices<S>(data), vector_(data) {}
 
   template <typename V2, typename T2, typename S2>
-  matrix(const cpp11::matrix<V2, T2, S2>& rhs) : matrix_slices<S>(rhs), vector_(rhs) {}
+  matrix(const cpp11::matrix<V2, T2, S2>& rhs)
+      : matrix_slices<S>(rhs.nrow(), rhs.ncol()), vector_(rhs.vector()) {}
 
   matrix(int nrow, int ncol)
       : matrix_slices<S>(nrow, ncol), vector_(R_xlen_t(nrow * ncol)) {
@@ -178,6 +179,8 @@ class matrix : public matrix_slices<S> {
   using matrix_slices<S>::slice_size;
   using matrix_slices<S>::slice_stride;
   using matrix_slices<S>::slice_offset;
+
+  V vector() const { return vector_; }
 
   SEXP data() const { return vector_.data(); }
 

--- a/inst/include/cpp11/r_vector.hpp
+++ b/inst/include/cpp11/r_vector.hpp
@@ -1294,7 +1294,9 @@ inline SEXP r_vector<T>::reserve_data(SEXP x, bool is_altrep, R_xlen_t size) {
   // Resize names, if required
   SEXP names = Rf_getAttrib(x, R_NamesSymbol);
   if (names != R_NilValue) {
-    names = resize_names(names, size);
+    if (Rf_xlength(names) != size) {
+      names = resize_names(names, size);
+    }
     Rf_setAttrib(out, R_NamesSymbol, names);
   }
 


### PR DESCRIPTION
Reverts part of #383, specifically the note here https://github.com/r-lib/cpp11/pull/383/files#r1723749948

We really do need to call `Rf_shallow_duplicate()` because we want ALL of the attributes on the `rhs` to get copied over, even `dim` and `dimnames`.

`reserve_data()` is meant to be used when we KNOW we have a vector that `push_back()` has been called on, which should hopefully never be a `matrix` (there is no `matrix` API for this). If that holds, then it is ok that the `dim` and `dimnames` attributes get dropped on growth (i.e. during a `push_back()`) and truncation (i.e. in the `SEXP` operator).

The downside of this comes up when you do: `push_back()`, then use the copy constructor, then return that value. The copy constructor retains all the extra capacity (meaning the allocation is larger than it maybe needs to be), and then when we return the value we also have to truncate. But this combination is probably somewhat rare, so its fine.

---

Without this, literanger breaks. We have now added tests to ensure we can't break this again accidentally.