### PR TITLE
Guard uses of `get_p()` against `R_NilValue`

### DIFF
--- a/cpp11test/src/test-r_vector.cpp
+++ b/cpp11test/src/test-r_vector.cpp
@@ -274,6 +274,20 @@ context("r_vector-C++") {
     expect_true(after - before == 1);
   }
 
+  test_that("writable vector copy assignment works with default constructed vectors") {
+    // Default constructed - the `data_` is `R_NilValue`!
+    cpp11::writable::integers x;
+
+    cpp11::writable::integers y(1);
+
+    // Checks that this guards against calling `INTEGER()` on `R_NilValue`.
+    y = x;
+
+    SEXP z(y);
+    expect_true(cpp11::detail::r_typeof(z) == INTSXP);
+    expect_true(Rf_xlength(z) == 0);
+  }
+
   test_that("writable vector copy constructor correctly tracks the `capacity_`") {
     cpp11::writable::integers x(2);
     x[0] = 1;
@@ -296,6 +310,18 @@ context("r_vector-C++") {
     expect_true(y[1] == 2);
     expect_true(y[2] == 3);
     expect_true(y[3] == 4);
+  }
+
+  test_that("writable vector copy constructor works with default constructed vectors") {
+    // Default constructed - the `data_` is `R_NilValue`!
+    cpp11::writable::integers x;
+
+    // Checks that this guards against calling `INTEGER()` on `R_NilValue`.
+    cpp11::writable::integers y(x);
+
+    SEXP z(y);
+    expect_true(cpp11::detail::r_typeof(z) == INTSXP);
+    expect_true(Rf_xlength(z) == 0);
   }
 
   test_that(

--- a/inst/include/cpp11/r_vector.hpp
+++ b/inst/include/cpp11/r_vector.hpp
@@ -787,7 +787,7 @@ inline r_vector<T>::r_vector(const r_vector& rhs) {
   data_ = safe[Rf_shallow_duplicate](rhs.data_);
   protect_ = detail::store::insert(data_);
   is_altrep_ = ALTREP(data_);
-  data_p_ = get_p(is_altrep_, data_);
+  data_p_ = (data_ == R_NilValue) ? nullptr : get_p(is_altrep_, data_);
   length_ = rhs.length_;
   capacity_ = rhs.capacity_;
 }
@@ -925,7 +925,7 @@ inline r_vector<T>& r_vector<T>::operator=(const r_vector& rhs) {
   data_ = safe[Rf_shallow_duplicate](rhs.data_);
   protect_ = detail::store::insert(data_);
   is_altrep_ = ALTREP(data_);
-  data_p_ = get_p(is_altrep_, data_);
+  data_p_ = (data_ == R_NilValue) ? nullptr : get_p(is_altrep_, data_);
   length_ = rhs.length_;
   capacity_ = rhs.capacity_;
 


### PR DESCRIPTION
Found when looking at marquee failures

I don't think it makes sense to put this in `get_p()` itself. Many times we use `get_p()` but we know the data is not `R_NilValue` already.