### PR TITLE
Enable copy assignment operator for `iterator` class

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # cpp11 (development version)
 
+* `cpp11::writable::r_vector<T>::iterator` no longer implicitly deletes its
+  copy assignment operator (#360).
+
+* `std::max_element()` can now be used with writable vectors (#334).
+
 * The `environment` class no longer uses the non-API function
   `Rf_findVarInFrame3()` (#367).
 

--- a/cpp11test/src/test-r_vector.cpp
+++ b/cpp11test/src/test-r_vector.cpp
@@ -4,6 +4,8 @@
 
 #include <testthat.h>
 
+#include <algorithm>  // for max_element
+
 context("r_vector-C++") {
   test_that("read only vector capabilities") {
     using cpp11::integers;

--- a/cpp11test/src/test-r_vector.cpp
+++ b/cpp11test/src/test-r_vector.cpp
@@ -6,7 +6,15 @@
 
 #include <algorithm>  // for max_element
 
-context("r_vector-C++") {
+#ifdef _WIN32
+#include "Rversion.h"
+#define CPP11_HAS_IS_UTILITIES R_VERSION >= R_Version(4, 0, 0)
+#else
+#define CPP11_HAS_IS_UTILITIES 1
+#endif
+
+#if CPP11_HAS_IS_UTILITIES
+context("r_vector-capabilities-C++") {
   test_that("read only vector capabilities") {
     using cpp11::integers;
 
@@ -71,7 +79,10 @@ context("r_vector-C++") {
     expect_false(std::is_move_assignable<integers::proxy>::value);
     expect_false(std::is_trivially_move_assignable<integers::proxy>::value);
   }
+}
+#endif
 
+context("r_vector-C++") {
   test_that("writable vector temporary isn't leaked (integer) (#338)") {
     R_xlen_t before = cpp11::detail::store::count();
 

--- a/cpp11test/src/test-r_vector.cpp
+++ b/cpp11test/src/test-r_vector.cpp
@@ -49,11 +49,10 @@ context("r_vector-C++") {
     expect_true(std::is_trivially_destructible<integers::iterator>::value);
     expect_true(std::is_copy_constructible<integers::iterator>::value);
     expect_true(std::is_move_constructible<integers::iterator>::value);
-    // FIXME: These should be `true`!
-    // expect_true(std::is_copy_assignable<integers::iterator>::value);
-    // expect_true(std::is_trivially_copy_assignable<integers::iterator>::value);
-    // expect_true(std::is_move_assignable<integers::iterator>::value);
-    // expect_true(std::is_trivially_move_assignable<integers::iterator>::value);
+    expect_true(std::is_copy_assignable<integers::iterator>::value);
+    expect_true(std::is_trivially_copy_assignable<integers::iterator>::value);
+    expect_true(std::is_move_assignable<integers::iterator>::value);
+    expect_true(std::is_trivially_move_assignable<integers::iterator>::value);
   }
 
   test_that("writable proxy capabilities") {
@@ -461,5 +460,27 @@ context("r_vector-C++") {
     expect_true(x.data() == x_sexp);
 
     UNPROTECT(2);
+  }
+
+  test_that("std::max_element works on read only vectors") {
+    SEXP foo_sexp = PROTECT(Rf_allocVector(INTSXP, 5));
+    SET_INTEGER_ELT(foo_sexp, 0, 1);
+    SET_INTEGER_ELT(foo_sexp, 1, 2);
+    SET_INTEGER_ELT(foo_sexp, 2, 5);
+    SET_INTEGER_ELT(foo_sexp, 3, 4);
+    SET_INTEGER_ELT(foo_sexp, 4, 3);
+    cpp11::integers foo(foo_sexp);
+
+    auto element = std::max_element(foo.begin(), foo.end());
+
+    expect_true(*element == 5);
+
+    UNPROTECT(1);
+  }
+
+  test_that("std::max_element works on writable vectors (#334)") {
+    cpp11::writable::integers foo = {1, 2, 5, 4, 3};
+    auto element = std::max_element(foo.begin(), foo.end());
+    expect_true(*element == 5);
   }
 }

--- a/cpp11test/src/test-r_vector.cpp
+++ b/cpp11test/src/test-r_vector.cpp
@@ -5,6 +5,72 @@
 #include <testthat.h>
 
 context("r_vector-C++") {
+  test_that("read only vector capabilities") {
+    using cpp11::integers;
+
+    expect_true(std::is_destructible<integers>::value);
+    expect_true(std::is_default_constructible<integers>::value);
+    expect_true(std::is_nothrow_default_constructible<integers>::value);
+    expect_true(std::is_copy_constructible<integers>::value);
+    expect_true(std::is_move_constructible<integers>::value);
+    expect_true(std::is_copy_assignable<integers>::value);
+    expect_true(std::is_move_assignable<integers>::value);
+  }
+
+  test_that("writable vector capabilities") {
+    using cpp11::writable::integers;
+
+    expect_true(std::is_destructible<integers>::value);
+    expect_true(std::is_default_constructible<integers>::value);
+    expect_true(std::is_nothrow_default_constructible<integers>::value);
+    expect_true(std::is_copy_constructible<integers>::value);
+    expect_true(std::is_move_constructible<integers>::value);
+    expect_true(std::is_copy_assignable<integers>::value);
+    expect_true(std::is_move_assignable<integers>::value);
+  }
+
+  test_that("read only const_iterator capabilities") {
+    using cpp11::integers;
+
+    expect_true(std::is_destructible<integers::const_iterator>::value);
+    expect_true(std::is_trivially_destructible<integers::const_iterator>::value);
+    expect_true(std::is_copy_constructible<integers::const_iterator>::value);
+    expect_true(std::is_move_constructible<integers::const_iterator>::value);
+    expect_true(std::is_copy_assignable<integers::const_iterator>::value);
+    expect_true(std::is_trivially_copy_assignable<integers::const_iterator>::value);
+    expect_true(std::is_move_assignable<integers::const_iterator>::value);
+    expect_true(std::is_trivially_move_assignable<integers::const_iterator>::value);
+  }
+
+  test_that("writable iterator capabilities") {
+    using cpp11::writable::integers;
+
+    expect_true(std::is_destructible<integers::iterator>::value);
+    expect_true(std::is_trivially_destructible<integers::iterator>::value);
+    expect_true(std::is_copy_constructible<integers::iterator>::value);
+    expect_true(std::is_move_constructible<integers::iterator>::value);
+    // FIXME: These should be `true`!
+    // expect_true(std::is_copy_assignable<integers::iterator>::value);
+    // expect_true(std::is_trivially_copy_assignable<integers::iterator>::value);
+    // expect_true(std::is_move_assignable<integers::iterator>::value);
+    // expect_true(std::is_trivially_move_assignable<integers::iterator>::value);
+  }
+
+  test_that("writable proxy capabilities") {
+    using cpp11::writable::integers;
+
+    expect_true(std::is_destructible<integers::proxy>::value);
+    expect_true(std::is_trivially_destructible<integers::proxy>::value);
+    expect_true(std::is_copy_constructible<integers::proxy>::value);
+    expect_true(std::is_move_constructible<integers::proxy>::value);
+
+    // Should these be true? Does it affect anything in practice?
+    expect_false(std::is_copy_assignable<integers::proxy>::value);
+    expect_false(std::is_trivially_copy_assignable<integers::proxy>::value);
+    expect_false(std::is_move_assignable<integers::proxy>::value);
+    expect_false(std::is_trivially_move_assignable<integers::proxy>::value);
+  }
+
   test_that("writable vector temporary isn't leaked (integer) (#338)") {
     R_xlen_t before = cpp11::detail::store::count();
 

--- a/inst/include/cpp11/r_vector.hpp
+++ b/inst/include/cpp11/r_vector.hpp
@@ -102,6 +102,12 @@ class r_vector {
   const_iterator find(const r_string& name) const;
 
   class const_iterator {
+    // Iterator references:
+    // https://cplusplus.com/reference/iterator/
+    // https://stackoverflow.com/questions/8054273/how-to-implement-an-stl-style-iterator-and-avoid-common-pitfalls
+    // It seems like our iterator doesn't fully implement everything for
+    // `random_access_iterator_tag` (like an `[]` operator, for example). If we discover
+    // issues with it, we probably need to add more methods.
    private:
     const r_vector* data_;
     R_xlen_t pos_;

--- a/inst/include/cpp11/r_vector.hpp
+++ b/inst/include/cpp11/r_vector.hpp
@@ -282,8 +282,7 @@ class r_vector : public cpp11::r_vector<T> {
 
   class iterator : public cpp11::r_vector<T>::const_iterator {
    private:
-    const r_vector& data_;
-
+    using cpp11::r_vector<T>::const_iterator::data_;
     using cpp11::r_vector<T>::const_iterator::block_start_;
     using cpp11::r_vector<T>::const_iterator::pos_;
     using cpp11::r_vector<T>::const_iterator::buf_;
@@ -298,7 +297,7 @@ class r_vector : public cpp11::r_vector<T> {
     using reference = proxy&;
     using iterator_category = std::forward_iterator_tag;
 
-    iterator(const r_vector& data, R_xlen_t pos);
+    iterator(const r_vector* data, R_xlen_t pos);
 
     iterator& operator++();
 
@@ -1120,12 +1119,12 @@ inline void r_vector<T>::clear() {
 
 template <typename T>
 inline typename r_vector<T>::iterator r_vector<T>::begin() const {
-  return iterator(*this, 0);
+  return iterator(this, 0);
 }
 
 template <typename T>
 inline typename r_vector<T>::iterator r_vector<T>::end() const {
-  return iterator(*this, length_);
+  return iterator(this, length_);
 }
 
 template <typename T>
@@ -1238,13 +1237,13 @@ inline r_vector<T>::proxy::operator T() const {
 }
 
 template <typename T>
-r_vector<T>::iterator::iterator(const r_vector& data, R_xlen_t pos)
-    : r_vector::const_iterator(&data, pos), data_(data) {}
+r_vector<T>::iterator::iterator(const r_vector* data, R_xlen_t pos)
+    : r_vector::const_iterator(data, pos) {}
 
 template <typename T>
 inline typename r_vector<T>::iterator& r_vector<T>::iterator::operator++() {
   ++pos_;
-  if (use_buf(data_.is_altrep()) && pos_ >= block_start_ + length_) {
+  if (use_buf(data_->is_altrep()) && pos_ >= block_start_ + length_) {
     fill_buf(pos_);
   }
   return *this;
@@ -1252,21 +1251,21 @@ inline typename r_vector<T>::iterator& r_vector<T>::iterator::operator++() {
 
 template <typename T>
 inline typename r_vector<T>::proxy r_vector<T>::iterator::operator*() const {
-  if (use_buf(data_.is_altrep())) {
+  if (use_buf(data_->is_altrep())) {
     return proxy(
-        data_.data(), pos_,
+        data_->data(), pos_,
         const_cast<typename r_vector::underlying_type*>(&buf_[pos_ - block_start_]),
         true);
   } else {
-    return proxy(data_.data(), pos_,
-                 data_.data_p_ != nullptr ? &data_.data_p_[pos_] : nullptr, false);
+    return proxy(data_->data(), pos_,
+                 data_->data_p_ != nullptr ? &data_->data_p_[pos_] : nullptr, false);
   }
 }
 
 template <typename T>
 inline typename r_vector<T>::iterator& r_vector<T>::iterator::operator+=(R_xlen_t rhs) {
   pos_ += rhs;
-  if (use_buf(data_.is_altrep()) && pos_ >= block_start_ + length_) {
+  if (use_buf(data_->is_altrep()) && pos_ >= block_start_ + length_) {
     fill_buf(pos_);
   }
   return *this;


### PR DESCRIPTION
Closes https://github.com/r-lib/cpp11/issues/360
Closes https://github.com/r-lib/cpp11/issues/334

Expands on https://github.com/r-lib/cpp11/commit/686ae04f4c239735bdbe3e462731ae650ec6a225 to carry over some of these changes to `iterator` as well (i.e., not just `const_iterator`). Note that I have not changed `iterator` to be a `random_access_iterator_tag`, I left it as a `forward_iterator_tag`. Making a random access iterator requires many extra methods. I don't even think we implement all of them for `const_iterator`. I've added some comments about that and if we have issues in the future with iterators we should look and see if we just need more methods.