### PR TITLE
Protect the function wrapped by `cpp11::function`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # cpp11 (development version)
 
+* `cpp11::function` now protects its underlying function, for maximum safety
+  (#294).
+
 * `cpp11::writable::r_vector<T>::proxy` now implements copy assignment.
   Practically this means that `x[i] = y[i]` now works when both `x` and `y`
   are writable vectors (#300, #339).

--- a/inst/include/cpp11/function.hpp
+++ b/inst/include/cpp11/function.hpp
@@ -31,7 +31,7 @@ class function {
   }
 
  private:
-  SEXP data_;
+  sexp data_;
 
   template <typename... Args>
   void construct_call(SEXP val, const named_arg& arg, Args&&... args) const {
@@ -71,6 +71,7 @@ class package {
     return safe[Rf_findVarInFrame](R_NamespaceRegistry, name_sexp);
   }
 
+  // Either base env or in namespace registry, so no protection needed
   SEXP data_;
 };
 


### PR DESCRIPTION
Closes #294 

In theory this is as simple as changing `SEXP` to `sexp` in `cpp11::function`.

In practice, doing _just_ that breaks some protection list related "count" tests. In the tests we assert that the size of the protection list starts at 0 at the beginning of the test, and we'd like to keep that nice assertion / property. However, if we just change to `sexp` then the count won't start at 0 if we've run the `message()` related tests first. That's because `message()` previously maintained a `static cpp11::function` variable holding `base::message`. Switching to `sexp` means that we now always maintains a protection list count of >0, because it never releases `base::message`. My solution is to switch away from `static cpp11::function` to a lower level method through `r_message()` that doesn't use the cpp11 protection list.