### PR TITLE
Error if `get_namespace()` fails

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # cpp11 (development version)
 
+* `cpp11::package` now errors if given a package name that hasn't been loaded
+  yet. Previously it would cause R to hang indefinitely (#317).
+
 * `cpp11::function` now protects its underlying function, for maximum safety
   (#294).
 

--- a/cpp11test/src/test-function.cpp
+++ b/cpp11test/src/test-function.cpp
@@ -36,4 +36,8 @@ context("function-C++") {
 
     close(con);
   }
+
+  test_that("unknown packages cause an error (#317)") {
+    expect_error_as(cpp11::package("definitely_not_a_package"), cpp11::unwind_exception);
+  }
 }

--- a/inst/include/cpp11/function.hpp
+++ b/inst/include/cpp11/function.hpp
@@ -68,7 +68,7 @@ class package {
       return R_BaseEnv;
     }
     sexp name_sexp = safe[Rf_install](name);
-    return safe[Rf_findVarInFrame](R_NamespaceRegistry, name_sexp);
+    return safe[detail::r_env_get](R_NamespaceRegistry, name_sexp);
   }
 
   // Either base env or in namespace registry, so no protection needed


### PR DESCRIPTION
Closes #317

Previously, this would hang indefinitely

```r
cpp11::cpp_function('
SEXP test() {
  auto fn = cpp11::package("foo")["bar"];
  return fn();
}
')

test()
#> Error: object 'foo' not found
```

Now it at least says `foo` is not found, the same error that any other environment lookup failure would throw