### PR TITLE
fix compilation warnings on Niagara clusters

### DIFF
--- a/inst/include/cpp11/doubles.hpp
+++ b/inst/include/cpp11/doubles.hpp
@@ -48,7 +48,7 @@ inline void r_vector<double>::get_region(SEXP x, R_xlen_t i, R_xlen_t n,
                                          typename r_vector::underlying_type* buf) {
   // NOPROTECT: likely too costly to unwind protect here
   REAL_GET_REGION(x, i, n, buf);
-};
+}
 
 template <>
 inline bool r_vector<double>::const_iterator::use_buf(bool is_altrep) {

--- a/inst/include/cpp11/integers.hpp
+++ b/inst/include/cpp11/integers.hpp
@@ -49,7 +49,7 @@ inline void r_vector<int>::get_region(SEXP x, R_xlen_t i, R_xlen_t n,
                                       typename r_vector::underlying_type* buf) {
   // NOPROTECT: likely too costly to unwind protect here
   INTEGER_GET_REGION(x, i, n, buf);
-};
+}
 
 template <>
 inline bool r_vector<int>::const_iterator::use_buf(bool is_altrep) {

--- a/inst/include/cpp11/list.hpp
+++ b/inst/include/cpp11/list.hpp
@@ -52,7 +52,7 @@ template <>
 inline void r_vector<SEXP>::get_region(SEXP x, R_xlen_t i, R_xlen_t n,
                                        typename r_vector::underlying_type* buf) {
   cpp11::stop("Unreachable!");
-};
+}
 
 template <>
 inline bool r_vector<SEXP>::const_iterator::use_buf(bool is_altrep) {

--- a/inst/include/cpp11/logicals.hpp
+++ b/inst/include/cpp11/logicals.hpp
@@ -48,7 +48,7 @@ inline void r_vector<r_bool>::get_region(SEXP x, R_xlen_t i, R_xlen_t n,
                                          typename r_vector::underlying_type* buf) {
   // NOPROTECT: likely too costly to unwind protect here
   LOGICAL_GET_REGION(x, i, n, buf);
-};
+}
 
 template <>
 inline bool r_vector<r_bool>::const_iterator::use_buf(bool is_altrep) {

--- a/inst/include/cpp11/r_vector.hpp
+++ b/inst/include/cpp11/r_vector.hpp
@@ -420,7 +420,7 @@ inline r_vector<T>& r_vector<T>::operator=(const r_vector& rhs) {
   length_ = rhs.length_;
 
   return *this;
-};
+}
 
 // Same reasoning as `r_vector(r_vector&& x)` constructor
 template <typename T>
@@ -446,7 +446,7 @@ inline r_vector<T>& r_vector<T>::operator=(r_vector&& rhs) {
   rhs.length_ = 0;
 
   return *this;
-};
+}
 
 template <typename T>
 inline r_vector<T>::operator SEXP() const {

--- a/inst/include/cpp11/raws.hpp
+++ b/inst/include/cpp11/raws.hpp
@@ -56,7 +56,7 @@ inline void r_vector<uint8_t>::get_region(SEXP x, R_xlen_t i, R_xlen_t n,
                                           typename r_vector::underlying_type* buf) {
   // NOPROTECT: likely too costly to unwind protect here
   RAW_GET_REGION(x, i, n, buf);
-};
+}
 
 template <>
 inline bool r_vector<uint8_t>::const_iterator::use_buf(bool is_altrep) {

--- a/inst/include/cpp11/strings.hpp
+++ b/inst/include/cpp11/strings.hpp
@@ -49,7 +49,7 @@ template <>
 inline void r_vector<r_string>::get_region(SEXP x, R_xlen_t i, R_xlen_t n,
                                            typename r_vector::underlying_type* buf) {
   cpp11::stop("Unreachable!");
-};
+}
 
 template <>
 inline bool r_vector<r_string>::const_iterator::use_buf(bool is_altrep) {


### PR DESCRIPTION
Hi Davis

I hope you are doing well.

I am using cpp11 with vendoring to run my codes in the [Niagara](https://www.scinethpc.ca/niagara/) clusters. When I run my codes there, I get these warnings

```
── R CMD INSTALL ───────────────────────────────────────────────────────────────
─  installing *source* package ‘blazebenchmark’ ... (386ms)
   ** using staged installation
   ** libs
   g++ -std=gnu++14 -I"/scinet/niagara/software/2019b/opt/gcc-8.3.0/r/4.2.2-batteries-included/lib64/R/include" -DNDEBUG   -I/usr/local/include   -DARMA_OPENMP_THREADS=40 -I../inst/include -fpic  -O2 -ftree-vectorize -march=native  -UNDEBUG -Wall -pedantic -g -O0 -fdiagnostics-color=always -c 01_own_functions.cpp -o 

   ../inst/include/cpp11/r_vector.hpp:425:2: warning: extra ‘;’ [-Wpedantic]
   ../inst/include/cpp11/r_vector.hpp:451:2: warning: extra ‘;’ [-Wpedantic]
   ../inst/include/cpp11/list.hpp:57:2: warning: extra ‘;’ [-Wpedantic]
   ../inst/include/cpp11/doubles.hpp:53:2: warning: extra ‘;’ [-Wpedantic]
   ../inst/include/cpp11/integers.hpp:54:2: warning: extra ‘;’ [-Wpedantic]
   ../inst/include/cpp11/logicals.hpp:53:2: warning: extra ‘;’ [-Wpedantic]
   ../inst/include/cpp11/raws.hpp:61:2: warning: extra ‘;’ [-Wpedantic]
   ../inst/include/cpp11/strings.hpp:54:2: warning: extra ‘;’ [-Wpedantic]
```

This PR solves that and it works exactly the same with with a cleaner log.

Best,