### PR TITLE
Restore `CPP11_UNWIND` for backwards compatibility

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,13 +6,18 @@
   have not already been defined elsewhere. This is motivated by the fact that
   `R_NO_REMAP` is becoming the default for C++ code in R 4.5.0 (#410).
 
-* Because cpp11 now requires R >=4.0.0 and `R_UnwindProtect()` is always
-  available, `HAS_UNWIND_PROTECT` is no longer useful. Please avoid using it,
-  as we'd like to remove it in the future (#411).
+* Because cpp11 now requires R >=4.0.0, a number of previously optional tools
+  are now always available, allowing us to remove some dead code. In
+  particular:
+  
+  * `R_UnwindProtect()` is always available, so the defines `HAS_UNWIND_PROTECT`
+    and `CPP11_UNWIND` are no longer useful.
 
-* Because cpp11 now requires R >=4.0.0 and ALTREP is always available, the
-  `cpp11/altrep.hpp` file is no longer useful. Please avoid using `#include "cpp11/altrep.hpp"` and `HAS_ALTREP` as we'd like to remove them in the
-  future (#411).
+  * ALTREP is always available, so the file `cpp11/altrep.hpp` and the define
+    `HAS_ALTREP` are no longer useful.
+
+  We would like to remove the dead code regarding these tools in the future, so
+  we ask that you please remove usage of them from your own packages (#411).
 
 * cpp11 now requires R >=4.0.0, in line with the
   [tidyverse version policy](https://www.tidyverse.org/blog/2019/04/r-version-support/) (#411).

--- a/inst/include/cpp11/altrep.hpp
+++ b/inst/include/cpp11/altrep.hpp
@@ -2,5 +2,5 @@
 
 // It would be nice to remove this since all supported versions of R have ALTREP, but
 // some groups rely on both this `#define` and `altrep.hpp` itself existing, like arrow:
-// https://github.com/apache/arrow/blob/50f2d6e04e8323119d4dd31506827ee398d6b8e4/r/src/altrep.cpp#L27-L29
+// https://github.com/r-lib/cpp11/issues/413
 #define HAS_ALTREP

--- a/inst/include/cpp11/declarations.hpp
+++ b/inst/include/cpp11/declarations.hpp
@@ -30,6 +30,11 @@ T& unmove(T&& t) {
 }
 }  // namespace cpp11
 
+// We would like to remove this, since all supported versions of R now support proper
+// unwind protect, but some groups rely on it existing, like textshaping:
+// https://github.com/r-lib/cpp11/issues/414
+#define CPP11_UNWIND R_ContinueUnwind(err);
+
 #define CPP11_ERROR_BUFSIZE 8192
 
 #define BEGIN_CPP11                   \

--- a/inst/include/cpp11/protect.hpp
+++ b/inst/include/cpp11/protect.hpp
@@ -16,8 +16,7 @@
 
 // We would like to remove this, since all supported versions of R now support proper
 // unwind protect, but some groups rely on it existing, like arrow and systemfonts
-// https://github.com/r-lib/systemfonts/blob/02b567086379edaca1a9b3620ad6776e6bb876a7/src/utils.h#L11
-// https://github.com/apache/arrow/blob/50f2d6e04e8323119d4dd31506827ee398d6b8e4/r/src/safe-call-into-r-impl.cpp#L49
+// https://github.com/r-lib/cpp11/issues/412
 #define HAS_UNWIND_PROTECT
 
 #ifdef CPP11_USE_FMT


### PR DESCRIPTION
Follow up to #411 since textshaping used `CPP11_UNWIND`. Related to https://github.com/r-lib/cpp11/issues/414