### PR TITLE
fix: Copy strings before calling `Rf_warningcall()` to avoid weird unwind behavior

### DIFF
--- a/inst/include/cpp11/protect.hpp
+++ b/inst/include/cpp11/protect.hpp
@@ -201,14 +201,10 @@ void stop [[noreturn]] (const std::string& fmt_arg, Args&&... args) {
   safe.noreturn(Rf_errorcall)(R_NilValue, "%s", msg.c_str());
 }
 
-template <typename... Args>
-void warning(const char* fmt_arg, Args&&... args) {
-  std::string msg = fmt::format(fmt_arg, std::forward<Args>(args)...);
-  safe[Rf_warningcall](R_NilValue, "%s", msg.c_str());
-}
+// Always making copy of string to avoid weird unwind behavior.
 
 template <typename... Args>
-void warning(const std::string& fmt_arg, Args&&... args) {
+void warning(const std::string fmt_arg, Args&&... args) {
   std::string msg = fmt::format(fmt_arg, std::forward<Args>(args)...);
   safe[Rf_warningcall](R_NilValue, "%s", msg.c_str());
 }
@@ -223,13 +219,10 @@ void stop [[noreturn]] (const std::string& fmt, Args... args) {
   safe.noreturn(Rf_errorcall)(R_NilValue, fmt.c_str(), args...);
 }
 
-template <typename... Args>
-void warning(const char* fmt, Args... args) {
-  safe[Rf_warningcall](R_NilValue, fmt, args...);
-}
+// Always making copy of string to avoid weird unwind behavior.
 
 template <typename... Args>
-void warning(const std::string& fmt, Args... args) {
+void warning(const std::string fmt, Args... args) {
   safe[Rf_warningcall](R_NilValue, fmt.c_str(), args...);
 }
 #endif


### PR DESCRIPTION
From duckdb, see #401.

I'd need to dig up the motivation here, but I'm pretty sure this made a difference at some point.