### PR TITLE
Remove unprotect calls that rchk claims to be over unprotecting.

### DIFF
--- a/inst/include/cpp11/protect.hpp
+++ b/inst/include/cpp11/protect.hpp
@@ -299,8 +299,6 @@ inline SEXP insert(SEXP x) {
   SETCDR(head, cell);
   SETCAR(next, cell);
 
-  UNPROTECT(2);
-
   return cell;
 }
 

--- a/inst/include/cpp11/protect.hpp
+++ b/inst/include/cpp11/protect.hpp
@@ -281,21 +281,17 @@ inline SEXP insert(SEXP x) {
     return R_NilValue;
   }
 
-  PROTECT(x);
-
   SEXP list = get();
 
   // Get references to the head of the preserve list and the next element
-  // after the head
   SEXP head = list;
   SEXP next = CDR(list);
 
-  // Add a new cell that points to the current head + next.
-  SEXP cell = PROTECT(Rf_cons(head, next));
+  // Create the new cell
+  SEXP cell = Rf_cons(head, next);
   SET_TAG(cell, x);
 
-  // Update the head + next to point at the newly-created cell,
-  // effectively inserting that cell between the current head + next.
+  // Update the list structure
   SETCDR(head, cell);
   SETCAR(next, cell);
 

--- a/inst/include/cpp11/r_vector.hpp
+++ b/inst/include/cpp11/r_vector.hpp
@@ -1339,6 +1339,8 @@ inline SEXP r_vector<T>::reserve_data(SEXP x, bool is_altrep, R_xlen_t size) {
   // Does not look like it would ever error in our use cases, so no `safe[]`.
   Rf_copyMostAttrib(x, out);
 
+  UNPROTECT(2);
+
   return out;
 }
 
@@ -1363,6 +1365,8 @@ inline SEXP r_vector<T>::resize_data(SEXP x, bool is_altrep, R_xlen_t size) {
     }
   }
 
+  UNPROTECT(1);
+
   return out;
 }
 
@@ -1383,6 +1387,8 @@ inline SEXP r_vector<T>::resize_names(SEXP x, R_xlen_t size) {
   for (R_xlen_t i = copy_size; i < size; ++i) {
     SET_STRING_ELT(out, i, R_BlankString);
   }
+
+  UNPROTECT(1);
 
   return out;
 }

--- a/inst/include/cpp11/r_vector.hpp
+++ b/inst/include/cpp11/r_vector.hpp
@@ -1339,7 +1339,6 @@ inline SEXP r_vector<T>::reserve_data(SEXP x, bool is_altrep, R_xlen_t size) {
   // Does not look like it would ever error in our use cases, so no `safe[]`.
   Rf_copyMostAttrib(x, out);
 
-  UNPROTECT(2);
   return out;
 }
 
@@ -1364,7 +1363,6 @@ inline SEXP r_vector<T>::resize_data(SEXP x, bool is_altrep, R_xlen_t size) {
     }
   }
 
-  UNPROTECT(1);
   return out;
 }
 
@@ -1386,7 +1384,6 @@ inline SEXP r_vector<T>::resize_names(SEXP x, R_xlen_t size) {
     SET_STRING_ELT(out, i, R_BlankString);
   }
 
-  UNPROTECT(1);
   return out;
 }
 


### PR DESCRIPTION
While checking against `rhub/rchk` the {phutil} package I am about to submit to CRAN, it spotted:

```bash
Function cpp11::detail::store::insert(SEXPREC*)
  [PB] has negative depth /github/home/R/x86_64-pc-linux-gnu-library/4.6/cpp11/include/cpp11/protect.hpp:302
  [UP] attempt to unprotect more items (2) than protected (0), results will be incomplete /github/home/R/x86_64-pc-linux-gnu-library/4.6/cpp11/include/cpp11/protect.hpp:302
  [PB] has possible protection stack imbalance /github/home/R/x86_64-pc-linux-gnu-library/4.6/cpp11/include/cpp11/protect.hpp:305

Function cpp11::writable::r_vector<double>::reserve_data(SEXPREC*, bool, long)
  [PB] has negative depth /github/home/R/x86_64-pc-linux-gnu-library/4.6/cpp11/include/cpp11/r_vector.hpp:1342
  [UP] attempt to unprotect more items (2) than protected (0), results will be incomplete /github/home/R/x86_64-pc-linux-gnu-library/4.6/cpp11/include/cpp11/r_vector.hpp:1342
  [PB] has possible protection stack imbalance /github/home/R/x86_64-pc-linux-gnu-library/4.6/cpp11/include/cpp11/r_vector.hpp:1343

Function cpp11::writable::r_vector<double>::resize_data(SEXPREC*, bool, long)
  [PB] has negative depth /github/home/R/x86_64-pc-linux-gnu-library/4.6/cpp11/include/cpp11/r_vector.hpp:1367
  [UP] attempt to unprotect more items (1) than protected (0), results will be incomplete /github/home/R/x86_64-pc-linux-gnu-library/4.6/cpp11/include/cpp11/r_vector.hpp:1367
  [PB] has possible protection stack imbalance /github/home/R/x86_64-pc-linux-gnu-library/4.6/cpp11/include/cpp11/r_vector.hpp:1368

Function cpp11::writable::r_vector<double>::resize_names(SEXPREC*, long)
  [PB] has negative depth /github/home/R/x86_64-pc-linux-gnu-library/4.6/cpp11/include/cpp11/r_vector.hpp:1389
  [UP] attempt to unprotect more items (1) than protected (0), results will be incomplete /github/home/R/x86_64-pc-linux-gnu-library/4.6/cpp11/include/cpp11/r_vector.hpp:1389
```

Full details here: https://github.com/tdaverse/phutil/actions/runs/14893316603/job/41830462913.

I therefore temporarily vendored {cpp11} headers and removed the `UNPROTECT()` calls and now `rchk` does not complain anymore.

This PR proposes their removal but maybe it needs more tests/investigation.