### PR TITLE
Use `macos-15-intel` instead of deprecated `macos-13`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-13,       r: 'oldrel'}
+          - {os: macos-15-intel, r: 'oldrel'}
           - {os: macos-latest,   r: 'release'}
 
           - {os: windows-latest, r: 'release'}


### PR DESCRIPTION
This should work until August 2027, at which point we can probably drop Intel support entirely https://github.com/actions/runner-images/issues/13045